### PR TITLE
perf: update CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,48 @@
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
-# rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.loongarch64-unknown-linux-gnu]
+linker = "loongarch64-linux-gnu-gcc"
+
+[target.s390x-unknown-linux-gnu]
+linker = "s390x-linux-gnu-gcc"
+
+[target.riscv64gc-unknown-linux-gnu]
+linker = "riscv64-linux-gnu-gcc"
+
+[target.powerpc64le-unknown-linux-gnu]
+linker = "powerpc64le-linux-gnu-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "gcc"
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.armv7-unknown-linux-musleabihf]
+linker = "gcc"
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.loongarch64-unknown-linux-musl]
+linker = "gcc"
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.powerpc64le-unknown-linux-musl]
+linker = "gcc"
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.riscv64gc-unknown-linux-musl]
+linker = "gcc"
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.s390x-unknown-linux-musl]
+linker = "gcc"
+rustflags = ["-C", "target-feature=-crt-static"]
 
 [target.x86_64-unknown-linux-musl]
 linker = "gcc"
 rustflags = ["-C", "target-feature=-crt-static"]
-
-[target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"
 
 [env]
 TS_RS_EXPORT_DIR = { value = "./landscape-webui/src/rust_bindings", relative = true }

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -2,180 +2,258 @@ name: build and release
 
 on:
   push:
-    tags:
-      - '*'
+
+env:
+  sccache_version: 'v0.12.0'
+  zlib_version: '1.3.1'
+  elfutils_version: '0.192'
 
 jobs:
-  # build-arm-musl:
-  #   runs-on: ubuntu-24.04-arm
-  #   container: rust:alpine3.22
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  linux-build:
+    runs-on: ${{ matrix.settings.host }}
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: ubuntu-22.04
+            architecture: x86_64
+            target: x86_64-unknown-linux-gnu
+            toolchain: stable
+            bindgen: false
 
-  #     - name: Build Rust binaries
-  #       run: |
-  #         mkdir -p output
-  #         rustup component add rustfmt
-  #         apk update && apk add --no-cache clang gcc build-base make pkgconf elfutils-dev linux-headers
-  #         pwd
-  #         ls -la
-  #         cargo build --release
-  #         cp target/release/landscape-webserver output/landscape-webserver-aarch64-musl
-  #         # redirect_pkg_handler
-  #         cargo build --package landscape-ebpf --bin redirect_pkg_handler --release
-  #         cp target/release/redirect_pkg_handler output/redirect_pkg_handler-aarch64-musl
+          # - host: ubuntu-22.04-arm
+          #   architecture: armv7l
+          #   target: armv7-unknown-linux-gnueabihf
+          #   toolchain: nightly
+          #   bindgen: true
 
-  #     - name: Upload Rust aarch64 binary
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: landscape-webserver-aarch64-musl
-  #         path: output/landscape-webserver-aarch64-musl
-      
-  #     - name: Upload redirect_pkg_handler aarch64 binary
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: redirect_pkg_handler-aarch64-musl
-  #         path: output/redirect_pkg_handler-aarch64-musl
-  build-musl:
-    runs-on: ubuntu-latest
-    container: thisseanzhang/landscape:build_base_musl
+          - host: ubuntu-22.04-arm
+            architecture: aarch64
+            target: aarch64-unknown-linux-gnu
+            toolchain: stable
+            bindgen: false
+
+          # - host: ubuntu-22.04
+          #   architecture: ppc64le
+          #   target: powerpc64le-unknown-linux-gnu
+          #   toolchain: stable
+          #   bindgen: true
+
+          - host: ubuntu-24.04
+            architecture: riscv64
+            target: riscv64gc-unknown-linux-gnu
+            toolchain: stable
+            bindgen: false
+
+          - host: ubuntu-24.04
+            architecture: s390x
+            target: s390x-unknown-linux-gnu
+            toolchain: stable
+            bindgen: true
+
+          - host: ubuntu-24.04
+            architecture: loongarch64
+            target: loongarch64-unknown-linux-gnu
+            toolchain: stable
+            bindgen: true
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake clang curl gcc llvm make pkg-config libelf-dev libclang-dev zlib1g-dev zstd
+
+      - name: Setup sccache
+        run: |
+          sccache_arch=${{ matrix.settings.architecture }}
+          if [ "${sccache_arch}" = "x86_64" ] || [ "${sccache_arch}" = "aarch64" ]; then
+            wget -qO- https://github.com/mozilla/sccache/releases/download/${sccache_version}/sccache-${sccache_version}-${sccache_arch}-unknown-linux-musl.tar.gz | sudo tar -xzf - -C /usr/local/bin/ --strip-components=1
+            echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          fi
+
+      - name: Setup cross-tools
+        if: ${{ !(matrix.settings.architecture == 'x86_64' || matrix.settings.architecture == 'aarch64') }}
+        run: |
+          ARCH=${{ matrix.settings.architecture }}
+          case "$ARCH" in
+            armv7l)
+              TOOLCHAIN_TRIPLET="arm-linux-gnueabihf"
+              ;;
+            ppc64le)
+              TOOLCHAIN_TRIPLET="powerpc64le-linux-gnu"
+              ;;
+            *)
+              TOOLCHAIN_TRIPLET="${ARCH}-linux-gnu"
+              ;;
+          esac
+
+          sudo apt-get update
+          sudo apt-get install -y g++-13-${TOOLCHAIN_TRIPLET} gcc-13-${TOOLCHAIN_TRIPLET}
+          sudo update-alternatives \
+            --install /usr/bin/${TOOLCHAIN_TRIPLET}-gcc ${TOOLCHAIN_TRIPLET}-gcc /usr/bin/${TOOLCHAIN_TRIPLET}-gcc-13 100 \
+            --slave /usr/bin/${TOOLCHAIN_TRIPLET}-gcc-ar ${TOOLCHAIN_TRIPLET}-gcc-ar /usr/bin/${TOOLCHAIN_TRIPLET}-gcc-ar-13 \
+            --slave /usr/bin/${TOOLCHAIN_TRIPLET}-gcc-nm ${TOOLCHAIN_TRIPLET}-gcc-nm /usr/bin/${TOOLCHAIN_TRIPLET}-gcc-nm-13 \
+            --slave /usr/bin/${TOOLCHAIN_TRIPLET}-gcc-ranlib ${TOOLCHAIN_TRIPLET}-gcc-ranlib /usr/bin/${TOOLCHAIN_TRIPLET}-gcc-ranlib-13 \
+            --slave /usr/bin/${TOOLCHAIN_TRIPLET}-gcov ${TOOLCHAIN_TRIPLET}-gcov /usr/bin/${TOOLCHAIN_TRIPLET}-gcov-13
+          sudo update-alternatives \
+            --install /usr/bin/${TOOLCHAIN_TRIPLET}-g++ ${TOOLCHAIN_TRIPLET}-g++ /usr/bin/${TOOLCHAIN_TRIPLET}-g++-13 100
+          sudo update-alternatives \
+            --install /usr/bin/${TOOLCHAIN_TRIPLET}-cpp ${TOOLCHAIN_TRIPLET}-cpp /usr/bin/${TOOLCHAIN_TRIPLET}-cpp-13 100
+
+          cd /tmp
+          wget -q https://zlib.net/zlib-${zlib_version}.tar.gz
+          wget -q https://sourceware.org/elfutils/ftp/${elfutils_version}/elfutils-${elfutils_version}.tar.bz2
+          tar xf zlib-${zlib_version}.tar.gz
+          tar xf elfutils-${elfutils_version}.tar.bz2
+
+          export CC=${TOOLCHAIN_TRIPLET}-gcc
+          export CXX=${TOOLCHAIN_TRIPLET}-g++
+          export PREFIX=/usr/${TOOLCHAIN_TRIPLET}
+          export LIBRARY_PATH=$PREFIX/lib
+          export LD_LIBRARY_PATH=$PREFIX/lib
+
+          cd /tmp/zlib-${zlib_version}
+          CHOST=${TOOLCHAIN_TRIPLET} ./configure --prefix=${PREFIX}
+          make -j$(nproc)
+          sudo make install
+
+          cd /tmp/elfutils-${elfutils_version}
+          ./configure --host=${TOOLCHAIN_TRIPLET} --prefix=${PREFIX} --with-zlib=${PREFIX} --disable-libdebuginfod --disable-debuginfod CFLAGS="-I${PREFIX}/include" LDFLAGS="-L${PREFIX}/lib -Wl,-rpath,$PREFIX/lib" LIBS="-lz"
+          make -j$(nproc)
+          sudo make install
+
+      - name: Setup rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.settings.toolchain }}
+          targets: ${{ matrix.settings.target }}
+          components: rustfmt
+
+      - name: Setup cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/sccache
+          key: ${{ runner.os }}-${{ matrix.settings.target }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-${{ matrix.settings.target }}-
+
+      - name: Build binaries
+        run: |
+            if [ "${{ matrix.settings.bindgen }}" = "true" ]; then
+              cargo install --force --locked bindgen-cli
+            fi
+            cargo build --release --target ${{ matrix.settings.target }}
+            cargo build --release --package landscape-ebpf --bin redirect_pkg_handler --target ${{ matrix.settings.target }}
+            mkdir -p output
+            cp target/${{ matrix.settings.target }}/release/landscape-webserver output/landscape-webserver-${{ matrix.settings.architecture }}
+            cp target/${{ matrix.settings.target }}/release/redirect_pkg_handler output/redirect_pkg_handler-${{ matrix.settings.architecture }}
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: landscape-webserver-${{ matrix.settings.target }}
+          path: output/*
+
+  linux-musl-build:
+    runs-on: ${{ matrix.settings.host }}
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: ubuntu-24.04
+            architecture: x86_64
+            target: x86_64-unknown-linux-musl
+            toolchain: stable
+            bindgen: false
+
+    container: 
+      image: thisseanzhang/landscape:build_base_musl
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup sccache
+        run: |
+          apk add --no-cache curl gzip tar wget
+          sccache_arch=${{ matrix.settings.architecture }}
+          if [ "${sccache_arch}" = "x86_64" ] || [ "${sccache_arch}" = "aarch64" ]; then
+            wget -qO- https://github.com/mozilla/sccache/releases/download/${sccache_version}/sccache-${sccache_version}-${sccache_arch}-unknown-linux-musl.tar.gz | tar -xzf - -C /usr/local/bin/ --strip-components=1
+            echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          fi
+
+      - name: Setup cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/sccache
+          key: ${{ runner.os }}-${{ matrix.settings.target }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-${{ matrix.settings.target }}-
 
       - name: Build Rust binaries
         run: |
           mkdir -p output
           cargo build --release
-          cp target/release/landscape-webserver output/landscape-webserver-x86_64-musl
+          cp target/release/landscape-webserver output/landscape-webserver-${{ matrix.settings.architecture }}-musl
           # redirect_pkg_handler
           cargo build --package landscape-ebpf --bin redirect_pkg_handler --release
-          cp target/release/redirect_pkg_handler output/redirect_pkg_handler-x86_64-musl
+          cp target/release/redirect_pkg_handler output/redirect_pkg_handler-${{ matrix.settings.architecture }}-musl
 
-      - name: Upload Rust x86_64 binary
+      - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: landscape-webserver-x86_64-musl
-          path: output/landscape-webserver-x86_64-musl
-      
-      - name: Upload redirect_pkg_handler x86_64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: redirect_pkg_handler-x86_64-musl
-          path: output/redirect_pkg_handler-x86_64-musl
-
-  build-rust:
-    runs-on: ubuntu-latest
-    container: thisseanzhang/landscape:build_base
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Build Rust binaries
-        run: |
-          mkdir -p output
-          cargo build --release
-          cp target/release/landscape-webserver output/landscape-webserver-x86_64
-          cargo build --target aarch64-unknown-linux-gnu --release
-          cp target/aarch64-unknown-linux-gnu/release/landscape-webserver output/landscape-webserver-aarch64
-          # redirect_pkg_handler
-          cargo build --package landscape-ebpf --bin redirect_pkg_handler --release
-          cp target/release/redirect_pkg_handler output/redirect_pkg_handler-x86_64
-          cargo build --package landscape-ebpf --bin redirect_pkg_handler --target aarch64-unknown-linux-gnu --release
-          cp target/aarch64-unknown-linux-gnu/release/redirect_pkg_handler output/redirect_pkg_handler-aarch64
-
-      - name: Upload redirect_pkg_handler x86_64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: redirect_pkg_handler-x86_64
-          path: output/redirect_pkg_handler-x86_64
-
-      - name: Upload redirect_pkg_handler aarch64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: redirect_pkg_handler-aarch64
-          path: output/redirect_pkg_handler-aarch64
-
-      - name: Upload Rust x86_64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: landscape-webserver-x86_64
-          path: output/landscape-webserver-x86_64
-
-      - name: Upload Rust aarch64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: landscape-webserver-aarch64
-          path: output/landscape-webserver-aarch64
+          name: landscape-webserver-${{ matrix.settings.target }}
+          path: output/*
 
   build-front:
     runs-on: ubuntu-latest
-    container: node:18.20.7-alpine3.21
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 18
+          cache: 'yarn'
+          cache-dependency-path: landscape-webui/yarn.lock
 
       - name: Build frontend
         run: |
           mkdir -p output
           cd landscape-webui
-          yarn install --cache-folder /yarn
-          NODE_OPTIONS="--max-old-space-size=1700" yarn build
+          yarn install
+          yarn build
           mkdir static && mv dist/* static/
-          apk add zip
           zip -r ../output/static.zip static
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
 
-      - name: Upload Frontend ZIP
+      - name: Upload frontend
         uses: actions/upload-artifact@v4
         with:
-          name: static.zip
+          name: landscape-frontend-none-all
           path: output/static.zip
 
   publish:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [build-rust, build-front, build-musl]
+    needs: [linux-build, linux-musl-build, build-front]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: Download x86_64 binary
+      - name: Download binary
         uses: actions/download-artifact@v4
         with:
-          name: landscape-webserver-x86_64
+          pattern: landscape-*
           path: output
-
-      - name: Download aarch64 binary
-        uses: actions/download-artifact@v4
-        with:
-          name: landscape-webserver-aarch64
-          path: output
-
-      - name: Download frontend static.zip
-        uses: actions/download-artifact@v4
-        with:
-          name: static.zip
-          path: output
-
-      - name: Download x86_64 musl redirect_pkg_handler binary
-        uses: actions/download-artifact@v4
-        with:
-          name: redirect_pkg_handler-x86_64-musl
-          path: output
-      - name: Download x86_64 redirect_pkg_handler binary
-        uses: actions/download-artifact@v4
-        with:
-          name: redirect_pkg_handler-x86_64
-          path: output
-      - name: Download aarch64 redirect_pkg_handler binary
-        uses: actions/download-artifact@v4
-        with:
-          name: redirect_pkg_handler-aarch64
-          path: output
+          merge-multiple: true
 
       - name: Generate SHASUM
         run: |
@@ -192,12 +270,6 @@ jobs:
           prerelease: true
           generate_release_notes: true
           files: |
-            output/landscape-webserver-x86_64
-            output/landscape-webserver-aarch64
-            output/static.zip
-            output/SHASUM256sum.txt
-            output/redirect_pkg_handler-x86_64
-            output/redirect_pkg_handler-x86_64-musl
-            output/redirect_pkg_handler-aarch64
+            output/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Provide binaries for riscv64, s390x, and loongarch64 architectures.
- Use sccache caching to accelerate build times.