### PR TITLE
feat(sysinfo): implement CPU temperature monitoring

### DIFF
--- a/landscape-webui/src/i18n/en/main.ts
+++ b/landscape-webui/src/i18n/en/main.ts
@@ -1,8 +1,10 @@
 export default {
   docker_divider: "Docker Containers",
   topology_divider: "Network topology",
-  total_cpu_usage: "Total Cpu Usage:",
-  average_load: "Average Load:",
+  total_cpu_usage: "Usage",
+  average_load: "Avg Load",
+  cpu_temp: "Avg Temp",
+  no_sensor: "No sensor data detected",
   mem: "Memory",
   used: "Used",
   swap: "Swap",

--- a/landscape-webui/src/i18n/zh/main.ts
+++ b/landscape-webui/src/i18n/zh/main.ts
@@ -1,8 +1,10 @@
 export default {
   docker_divider: "Docker 容器",
   topology_divider: "网络拓扑",
-  total_cpu_usage: "总 CPU 使用率:",
-  average_load: "平均负载:",
+  total_cpu_usage: "使用率",
+  average_load: "平均负载",
+  cpu_temp: "平均温度",
+  no_sensor: "未检测到传感器数据",
   mem: "内存",
   used: "已用",
   swap: "交换",

--- a/landscape-webui/src/lib/sys.ts
+++ b/landscape-webui/src/lib/sys.ts
@@ -15,6 +15,7 @@ export type CpuUsage = {
   vendor_id: string; // 厂商ID
   brand: string; // 品牌
   frequency: number; // 频率
+  temperature?: number; // 温度 (Optional)
 };
 
 // 内存使用情况
@@ -34,6 +35,7 @@ export type LoadAvg = {
 
 export class LandscapeStatus {
   global_cpu_info: number; // 全局 CPU 信息
+  global_cpu_temp?: number; // 全局 CPU 温度
   cpus: CpuUsage[]; // CPU 使用情况数组
   mem: MemUsage; // 内存使用情况
   uptime: number; // 系统运行时间
@@ -41,12 +43,14 @@ export class LandscapeStatus {
 
   constructor(obj?: {
     global_cpu_info: number;
+    global_cpu_temp?: number;
     cpus: CpuUsage[];
     mem: MemUsage;
     uptime: number;
     load_avg: LoadAvg;
   }) {
     this.global_cpu_info = obj?.global_cpu_info ?? 0;
+    this.global_cpu_temp = obj?.global_cpu_temp;
     this.cpus = obj?.cpus ?? [];
     this.mem = obj?.mem ?? {
       total_mem: 0,

--- a/landscape/src/routerstatus.rs
+++ b/landscape/src/routerstatus.rs
@@ -1,7 +1,7 @@
 use landscape_common::info::WatchResource;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
+use sysinfo::{Components, CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 
 /// CPU Usage
 #[derive(Clone, Serialize, Deserialize, Default)]
@@ -11,6 +11,8 @@ pub struct CpuUsage {
     vendor_id: String,
     brand: String,
     frequency: u64,
+    /// Temperature in Celsius (Optional)
+    pub temperature: Option<f32>,
 }
 
 impl From<&sysinfo::Cpu> for CpuUsage {
@@ -21,6 +23,7 @@ impl From<&sysinfo::Cpu> for CpuUsage {
             vendor_id: cpu.vendor_id().to_string(),
             brand: cpu.brand().to_string(),
             frequency: cpu.frequency(),
+            temperature: None, // Populated later via Components
         }
     }
 }
@@ -53,6 +56,8 @@ impl From<sysinfo::LoadAvg> for LoadAvg {
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct LandscapeStatus {
     pub global_cpu_info: f32,
+    /// Global/Package CPU Temperature in Celsius
+    pub global_cpu_temp: Option<f32>,
     pub cpus: Vec<CpuUsage>,
     pub mem: MemUsage,
     pub uptime: u64,
@@ -70,6 +75,8 @@ pub fn get_sys_running_status() -> WatchResource<LandscapeStatus> {
                 .with_cpu(CpuRefreshKind::everything())
                 .with_memory(MemoryRefreshKind::everything()),
         );
+        let mut components = Components::new_with_refreshed_list();
+
         loop {
             let mut ld_status = LandscapeStatus::default();
             ld_status.uptime = System::uptime();
@@ -77,10 +84,82 @@ pub fn get_sys_running_status() -> WatchResource<LandscapeStatus> {
 
             sys.refresh_cpu_all();
 
+            // Refresh temperature sensors
+            // Pass `false` to only update values of existing components, avoiding expensive re-scanning of /sys/class/hwmon.
+            // This ensures negligible performance impact even if called frequently (e.g. 1s).
+            components.refresh(false);
+
             ld_status.global_cpu_info = sys.global_cpu_usage();
 
-            for cpu in sys.cpus() {
-                ld_status.cpus.push(CpuUsage::from(cpu));
+            // Logic to map temperatures
+            // 1. Find global temperature (Package/Tdie/Tctl)
+            // 2. Map per-core temperatures if possible
+            let mut global_temp = None;
+            let mut core_temps: Vec<(usize, f32)> = Vec::new();
+            let mut temp_sum = 0.0;
+            let mut temp_count = 0;
+
+            // Prioritize specific labels for global temp
+            let mut found_priority = 100;
+
+            for component in &components {
+                let label = component.label();
+                if let Some(temp) = component.temperature() {
+                    // Heuristic for global temp
+                    let priority = if label.contains("Package id 0") {
+                        1 // Intel Package
+                    } else if label.contains("Tdie") {
+                        2 // AMD Die
+                    } else if label.contains("cpu_thermal") || label.contains("soc_thermal") {
+                        3 // Generic / ARM
+                    } else if label.contains("Tctl") {
+                        4 // AMD Control (often offset, less preferred than Die)
+                    } else {
+                        100
+                    };
+
+                    if priority < found_priority {
+                        global_temp = Some(temp);
+                        found_priority = priority;
+                    }
+
+                    // Heuristic for core temp: "Core 0", "Core 1", etc.
+                    // Note: This relies on "Core X" naming convention.
+                    if label.starts_with("Core") {
+                        if let Some(num_str) = label.split_whitespace().last() {
+                            if let Ok(core_idx) = num_str.parse::<usize>() {
+                                core_temps.push((core_idx, temp));
+                            }
+                        }
+                        // Also track for average fallback
+                        temp_sum += temp;
+                        temp_count += 1;
+                    }
+                }
+            }
+
+            // Fallback: if no global package temp found, use average of cores
+            if global_temp.is_none() && temp_count > 0 {
+                global_temp = Some(temp_sum / temp_count as f32);
+            }
+
+            ld_status.global_cpu_temp = global_temp;
+
+            for (i, cpu) in sys.cpus().iter().enumerate() {
+                let mut cpu_usage = CpuUsage::from(cpu);
+
+                // Try to find matching core temp
+                // Note: sysinfo cpus are usually ordered.
+                // Core X sensor usually maps to Physical Core X.
+                // For Hyper-Threading (HT), logical CPUs often exceed the number of physical core sensors.
+                // Strict mapping (Index i == Core i) is used here to ensure correctness for the first N cores.
+                // Logical threads sharing a core (e.g., CPU 4 on Core 0) will NOT inherit the temperature
+                // to avoid misleading data if the topology is unknown.
+                if let Some((_, temp)) = core_temps.iter().find(|(idx, _)| *idx == i) {
+                    cpu_usage.temperature = Some(*temp);
+                }
+
+                ld_status.cpus.push(cpu_usage);
             }
 
             sys.refresh_memory();


### PR DESCRIPTION
## Summary
This PR implements CPU temperature monitoring for both global (package) and per-core sensors.

## Changes
- **Backend**: Update `routerstatus` to collect temperature data using `sysinfo`.
  - Added heuristic logic to identify global temperature (Package id, Tdie, Tctl, etc.).
  - Added mapping for per-core temperatures.
  - Optimized performance by using `components.refresh(false)` to avoid expensive I/O.
- **Frontend**: Update `CPUUsage.vue` card.
  - Added "Avg Temp" / "平均温度" statistic.
  - Optimized layout to Flexbox to prevent layout shifts.
  - Added per-core temperature in tooltips.
  - Added "N/A" fallback with tooltip when sensors are missing.
- **i18n**: Added English and Chinese translations.

Fixes #114