### PR TITLE
Improve local build shell workflow

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,121 @@
+# Build and Development
+
+This is the canonical local development guide for the repository.
+
+## What to use
+
+- Use `cargo build --workspace` and `cargo test --workspace` for normal Rust development.
+- Use `./web.sh` for the frontend dev server.
+- Use `pnpm` for direct frontend commands. If you do not have a global `pnpm`, use `corepack pnpm`.
+- Use `bash ./build.sh -t <arch>` only for full integration or release-style builds.
+
+Do not use `build.sh` for every edit. It rebuilds the frontend, regenerates API bindings, stages release static assets, and produces release artifacts.
+
+## Requirements
+
+- Linux kernel `6.9+`
+- BTF/BPF enabled
+- Node.js `22+`
+- Rust toolchain
+
+Install the system packages used by CI:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y cmake clang curl gcc llvm make pkg-config libelf-dev libclang-dev zlib1g-dev zstd
+```
+
+## pnpm and Corepack
+
+This repository pins `pnpm` in [`package.json`](./package.json).
+
+If you already have `pnpm` installed globally, use it directly:
+
+```bash
+pnpm --version
+```
+
+If you do not want a global `pnpm`, use Corepack instead:
+
+```bash
+corepack enable
+corepack pnpm --version
+```
+
+If you want the `pnpm` command itself to be available through Corepack, run:
+
+```bash
+corepack enable pnpm
+```
+
+Repository wrapper scripts such as `./web.sh`, `./gen_ts_bindings.sh`, and `bash ./build.sh` already resolve `pnpm` through `scripts/pnpm_cmd.sh`. When Corepack is available and usable, they prefer `corepack pnpm`; otherwise they fall back to a global `pnpm`.
+
+Reference: <https://pnpm.io/installation#using-corepack>
+
+## Initial setup
+
+Install workspace dependencies:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+If you are using Corepack instead of a global `pnpm`, replace `pnpm` with `corepack pnpm`.
+
+The frontend imports generated code from `landscape-types`, so generate it before frontend work:
+
+```bash
+./gen_ts_bindings.sh
+```
+
+`./gen_ts_bindings.sh` exports `openapi.json` and regenerates the TypeScript client. Run it again whenever you change backend OpenAPI routes or schemas.
+
+## Daily development
+
+### Backend
+
+```bash
+cargo build --workspace
+cargo test --workspace
+```
+
+### Frontend
+
+```bash
+./web.sh
+```
+
+Equivalent direct command:
+
+```bash
+pnpm --filter landscape-webui dev
+```
+
+If the UI build fails with missing `@landscape-router/types/...` modules, regenerate `openapi.json` and `landscape-types`.
+
+`pnpm --filter landscape-webui build` builds the app bundle itself. Release-style static packaging, including the Scalar assets served by the backend, is handled by `bash ./build.sh -t <arch>`.
+
+## Full build
+
+Use this when you want the same general flow as CI:
+
+```bash
+bash ./build.sh -t x86_64
+```
+
+`build.sh` installs frontend dependencies, exports OpenAPI through `./gen_ts_bindings.sh`, regenerates TypeScript bindings, builds the web UI, stages the Scalar static assets under `output/static`, and then builds the release backend binary.
+
+## `sudo`
+
+Do not use `sudo` for dependency installation, formatting, type generation, or normal frontend and Rust builds.
+
+Use `sudo` only when running `landscape-webserver` on a real host, attaching eBPF programs, touching live interfaces, or validating real routing and packet-path behavior.
+
+## Before opening a PR
+
+```bash
+cargo fmt --all
+cargo test --workspace
+pnpm --filter landscape-webui exec prettier --check "src/**/*.{vue,ts,js,json,css,scss}"
+pnpm --filter landscape-webui build
+```

--- a/BUILD.zh.md
+++ b/BUILD.zh.md
@@ -1,0 +1,121 @@
+# 构建与本地开发
+
+本文件用于说明仓库的本地开发流程。如与 [BUILD.md](./BUILD.md) 不一致，以英文版为准。
+
+## 该用什么命令
+
+- 日常 Rust 开发使用 `cargo build --workspace` 和 `cargo test --workspace`
+- 前端开发优先使用 `./web.sh`
+- 前端命令使用 `pnpm`。如果你没有全局安装 `pnpm`，再使用 `corepack pnpm`
+- 只有在整仓联调或发布式构建时才使用 `bash ./build.sh -t <arch>`
+
+不要把 `build.sh` 当作日常开发入口。它会重建前端、重新生成 API 类型、整理 release 用静态资源，并产出 release 级别的构建结果。
+
+## 环境要求
+
+- Linux 内核 `6.9+`
+- 启用 BTF/BPF
+- Node.js `22+`
+- Rust 工具链
+
+系统依赖按 CI 安装：
+
+```bash
+sudo apt-get update
+sudo apt-get install -y cmake clang curl gcc llvm make pkg-config libelf-dev libclang-dev zlib1g-dev zstd
+```
+
+## pnpm 与 Corepack
+
+仓库在 [`package.json`](./package.json) 里锁定了 `pnpm` 版本。
+
+如果你已经全局安装了 `pnpm`，直接使用：
+
+```bash
+pnpm --version
+```
+
+如果你不想全局安装 `pnpm`，可以改用 Corepack：
+
+```bash
+corepack enable
+corepack pnpm --version
+```
+
+如果你希望本机可以直接输入 `pnpm`，还可以执行：
+
+```bash
+corepack enable pnpm
+```
+
+仓库里的包装脚本，例如 `./web.sh`、`./gen_ts_bindings.sh` 和 `bash ./build.sh`，都会通过 `scripts/pnpm_cmd.sh` 自动解析 `pnpm`。如果环境里有可用的 Corepack，会优先使用 `corepack pnpm`；否则再回退到全局 `pnpm`。
+
+参考：<https://pnpm.io/installation#using-corepack>
+
+## 初始化
+
+先安装工作区依赖：
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+如果你选择的是 Corepack 方式，请把文档里的 `pnpm` 替换成 `corepack pnpm`。
+
+前端会直接引用 `landscape-types` 中的生成代码，因此在开始前端开发前，需要先生成一次：
+
+```bash
+./gen_ts_bindings.sh
+```
+
+`./gen_ts_bindings.sh` 会导出 `openapi.json` 并重新生成 TypeScript client。修改了后端 OpenAPI 路由或 schema 之后，需要重新执行一次。
+
+## 日常开发
+
+### 后端
+
+```bash
+cargo build --workspace
+cargo test --workspace
+```
+
+### 前端
+
+```bash
+./web.sh
+```
+
+等价原生命令：
+
+```bash
+pnpm --filter landscape-webui dev
+```
+
+如果前端报 `@landscape-router/types/...` 缺失，先重新生成 `openapi.json` 和 `landscape-types`。
+
+`pnpm --filter landscape-webui build` 只负责构建前端应用本身。后端实际服务的 Scalar 静态资源整理属于 release-style 打包流程，由 `bash ./build.sh -t <arch>` 负责。
+
+## 整仓构建
+
+需要跑完整链路时执行：
+
+```bash
+bash ./build.sh -t x86_64
+```
+
+`build.sh` 会安装前端依赖，通过 `./gen_ts_bindings.sh` 导出 OpenAPI 并重新生成 TypeScript 类型、构建 Web UI、把 Scalar 静态资源整理到 `output/static`，然后再构建 release 后端二进制。
+
+## `sudo`
+
+依赖安装、格式化、类型生成、普通前端构建和普通 Rust 编译都不需要 `sudo`。
+
+只有在真实主机上运行 `landscape-webserver`、挂载 eBPF、操作真实网卡，或验证真实路由与 packet path 行为时才使用 `sudo`。
+
+## 提交前检查
+
+```bash
+cargo fmt --all
+cargo test --workspace
+pnpm --filter landscape-webui exec prettier --check "src/**/*.{vue,ts,js,json,css,scss}"
+pnpm --filter landscape-webui build
+```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Landscape is an eBPF-based Linux router platform that provides network service m
 [简体中文](./README.zh.md) | [English](./README.md)
 
 > Documentation: <https://landscape.whileaway.dev/en/>
+>
+> Development build guide: [BUILD.md](./BUILD.md) | [BUILD.zh.md](./BUILD.zh.md)
 
 ## Screenshot
 ![](main.png)

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,6 +14,8 @@ Landscape 是一个以 eBPF 为基础的 Linux 路由平台，提供网络服务
 [简体中文](./README.zh.md) | [English](./README.md)
 
 > 详细文档: <https://landscape.whileaway.dev/>
+>
+> 本地开发文档: [BUILD.md](./BUILD.md) | [BUILD.zh.md](./BUILD.zh.md)
 
 ## 截图
 ![](main.zh.png)

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,8 @@
 #!/usr/bin/env bash
 
-source ./build_env.sh
+set -euo pipefail
 
-# 更新依赖锁文件
-echo "更新 pnpm 依赖锁文件..."
-pnpm install || { echo "pnpm 依赖更新失败"; exit 1; }
-
-source ./scripts/build_webpage.sh
-
-source ./scripts/build_server.sh
-
-# source ./scripts/build_docker.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/build_env.sh"
+source "$SCRIPT_DIR/scripts/build_webpage.sh"
+source "$SCRIPT_DIR/scripts/build_server.sh"

--- a/build_env.sh
+++ b/build_env.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-# 记录脚本所在的**绝对路径**，以免后续 cd 导致路径混乱
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+set -euo pipefail
+
+# 记录脚本所在的绝对路径，避免后续 cd 或 source 导致路径混乱
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # 自动获取当前主机架构
 DEFAULT_ARCH="$(uname -m)"
@@ -15,6 +17,8 @@ declare -A TARGETS=(
     ["aarch64"]="aarch64-unknown-linux-gnu"
     ["armv7"]="armv7-unknown-linux-gnueabihf"
 )
+
+TARGET_ORDER=("x86_64" "aarch64" "armv7")
 
 # 对应 Docker 平台的架构
 declare -A DOCKER_ARCHS=(
@@ -30,18 +34,31 @@ TARGET=""
 function print_supported_archs() {
     echo "Supported architectures:"
     local i=1
-    for key in "${!TARGETS[@]}"; do
+    local key
+
+    for key in "${TARGET_ORDER[@]}"; do
         echo "$i) $key"
         i=$((i + 1))
     done
+
     echo "$i) Use default architecture ($DEFAULT_ARCH)"
 }
 
 # 提示用户选择架构
 function prompt_user_selection() {
+    if [[ ! -t 0 ]]; then
+        TARGET="$DEFAULT_ARCH"
+        return
+    fi
+
     print_supported_archs
     echo -n "Please select a target architecture by entering the corresponding number [default = $DEFAULT_ARCH]: "
-    read -r choice
+
+    local choice=""
+    if ! read -r choice; then
+        TARGET="$DEFAULT_ARCH"
+        return
+    fi
 
     # 如果用户直接回车（输入为空），使用默认架构
     if [[ -z "$choice" ]]; then
@@ -49,8 +66,15 @@ function prompt_user_selection() {
         return
     fi
 
+    if ! [[ "$choice" =~ ^[0-9]+$ ]]; then
+        echo "Invalid selection. Please enter a number."
+        prompt_user_selection
+        return
+    fi
+
     local i=1
-    for key in "${!TARGETS[@]}"; do
+    local key
+    for key in "${TARGET_ORDER[@]}"; do
         if [[ "$choice" -eq "$i" ]]; then
             TARGET="$key"
             return
@@ -72,6 +96,10 @@ function prompt_user_selection() {
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
         -t|--target)
+            if [[ "$#" -lt 2 ]]; then
+                echo "Missing value for $1"
+                exit 1
+            fi
             TARGET="$2"
             shift
             ;;
@@ -79,7 +107,7 @@ while [[ "$#" -gt 0 ]]; do
             print_supported_archs
             exit 0
             ;;
-        *) 
+        *)
             echo "Unknown option $1"
             exit 1
             ;;
@@ -94,7 +122,7 @@ if [[ -z "$TARGET" ]]; then
 fi
 
 # 检查用户输入的架构是否受支持
-if [[ -z "${TARGETS[$TARGET]}" ]]; then
+if [[ -z "${TARGETS[$TARGET]:-}" ]]; then
     echo "Unsupported architecture: $TARGET"
     echo "Use --list to see supported architectures."
     exit 1
@@ -104,8 +132,6 @@ fi
 TARGET_ARCH="${TARGETS[$TARGET]}"
 DOCKER_ARCH="${DOCKER_ARCHS[$TARGET]}"
 
-echo "Target platform set to: $TARGET"
-echo "Rust target: $TARGET_ARCH"
-echo "Docker architecture: $DOCKER_ARCH"
-
 export TARGET TARGET_ARCH DOCKER_ARCH
+
+source "$SCRIPT_DIR/scripts/pnpm_cmd.sh"

--- a/gen_ts_bindings.sh
+++ b/gen_ts_bindings.sh
@@ -1,9 +1,10 @@
-#!/bin/sh
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TYPES_DIR="$SCRIPT_DIR/landscape-types"
 API_DIR="$TYPES_DIR/src/api"
+source "$SCRIPT_DIR/scripts/pnpm_cmd.sh"
 
 # 1. Generate OpenAPI spec → landscape-types/openapi.json
 echo "Exporting OpenAPI spec..."
@@ -15,6 +16,9 @@ rm -rf "$API_DIR"
 
 # 3. Regenerate via orval
 echo "Running orval..."
-cd "$SCRIPT_DIR" && pnpm --filter @landscape-router/types generate
+(
+    cd "$SCRIPT_DIR"
+    pnpm_cmd --filter @landscape-router/types generate
+)
 
 echo "Done."

--- a/gen_ts_bindings.sh
+++ b/gen_ts_bindings.sh
@@ -6,18 +6,19 @@ TYPES_DIR="$SCRIPT_DIR/landscape-types"
 API_DIR="$TYPES_DIR/src/api"
 source "$SCRIPT_DIR/scripts/pnpm_cmd.sh"
 
-# 1. Generate OpenAPI spec → landscape-types/openapi.json
-echo "Exporting OpenAPI spec..."
-cargo test -p landscape-webserver export_openapi_json -- --nocapture
-
-# 2. Full clean generated dir
-echo "Cleaning generated API clients and schemas..."
-rm -rf "$API_DIR"
-
-# 3. Regenerate via orval
-echo "Running orval..."
 (
     cd "$SCRIPT_DIR"
+
+    # 1. Generate OpenAPI spec → landscape-types/openapi.json
+    echo "Exporting OpenAPI spec..."
+    cargo test -p landscape-webserver export_openapi_json -- --nocapture
+
+    # 2. Full clean generated dir
+    echo "Cleaning generated API clients and schemas..."
+    rm -rf "$API_DIR"
+
+    # 3. Regenerate via orval
+    echo "Running orval..."
     pnpm_cmd --filter @landscape-router/types generate
 )
 

--- a/scripts/build_server.sh
+++ b/scripts/build_server.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 echo "构建 Rust 项目..."
+cargo build --release --target "$TARGET_ARCH" --features=duckdb-bundled
 
-cargo build --release --target "$TARGET_ARCH" --features=duckdb-bundled || { echo "Rust 项目构建失败"; exit 1; }
-
-# 将 Rust 构建产物复制到对应架构的 release 文件夹
 echo "复制 Rust 构建产物到 $SCRIPT_DIR/output/landscape-webserver-$TARGET"
-# mkdir -p "$SCRIPT_DIR/output/$TARGET_ARCH"
+mkdir -p "$SCRIPT_DIR/output"
 cp "$SCRIPT_DIR/target/$TARGET_ARCH/release/landscape-webserver" "$SCRIPT_DIR/output/landscape-webserver-$TARGET"
-
-cd "$SCRIPT_DIR"

--- a/scripts/build_webpage.sh
+++ b/scripts/build_webpage.sh
@@ -1,28 +1,31 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 echo "SCRIPT_DIR: $SCRIPT_DIR"
 echo "Target platform set to: $TARGET"
 echo "Rust target: $TARGET_ARCH"
 echo "Docker architecture: $DOCKER_ARCH"
 
 echo "构建 Vue 项目..."
-cd "$SCRIPT_DIR" || { echo "找不到项目根目录"; exit 1; }
+cd "$SCRIPT_DIR"
 
-pnpm install --frozen-lockfile || { echo "依赖安装失败"; exit 1; }
+pnpm_cmd install --frozen-lockfile
 
-echo "复制 Scalar API Reference 资源..."
-mkdir -p "$SCRIPT_DIR/landscape-webui/public/scalar"
-cp "$SCRIPT_DIR/landscape-webui/node_modules/@scalar/api-reference/dist/browser/standalone.js" "$SCRIPT_DIR/landscape-webui/public/scalar/" || { echo "Scalar 资源复制失败"; exit 1; }
-cp "$SCRIPT_DIR/landscape-webui/node_modules/@scalar/api-reference/dist/style.css" "$SCRIPT_DIR/landscape-webui/public/scalar/" || { echo "Scalar CSS 复制失败"; exit 1; }
+"$SCRIPT_DIR/gen_ts_bindings.sh"
 
-pnpm --filter landscape-webui build || { echo "Vue 项目构建失败"; exit 1; }
+echo "复制 Scalar API Reference 资源到 output/static/scalar..."
+SCALAR_OUTPUT_DIR="$SCRIPT_DIR/output/static/scalar"
+SCALAR_JS_SRC="$SCRIPT_DIR/landscape-webui/node_modules/@scalar/api-reference/dist/browser/standalone.js"
+SCALAR_CSS_SRC="$SCRIPT_DIR/landscape-webui/node_modules/@scalar/api-reference/dist/style.css"
+
+pnpm_cmd --filter landscape-webui build
+
+rm -rf "$SCRIPT_DIR/output/static"
+mkdir -p "$SCALAR_OUTPUT_DIR"
 
 echo "复制 Vue 构建产物到 output/static..."
-mkdir -p "$SCRIPT_DIR/output/static"
-cp -r "$SCRIPT_DIR/landscape-webui/dist/"* "$SCRIPT_DIR/output/static/"
+cp -r "$SCRIPT_DIR/landscape-webui/dist/." "$SCRIPT_DIR/output/static/"
 
-# 复制 Scalar 资源到输出目录
-echo "复制 Scalar 资源到 output/static/scalar..."
-mkdir -p "$SCRIPT_DIR/output/static/scalar"
-cp "$SCRIPT_DIR/landscape-webui/public/scalar/"*.js "$SCRIPT_DIR/output/static/scalar/" 2>/dev/null || true
-cp "$SCRIPT_DIR/landscape-webui/public/scalar/"*.css "$SCRIPT_DIR/output/static/scalar/" 2>/dev/null || true
+cp "$SCALAR_JS_SRC" "$SCALAR_OUTPUT_DIR/standalone.js"
+cp "$SCALAR_CSS_SRC" "$SCALAR_OUTPUT_DIR/style.css"

--- a/scripts/pnpm_cmd.sh
+++ b/scripts/pnpm_cmd.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+pnpm_cmd() {
+    if command -v corepack >/dev/null 2>&1; then
+        if corepack pnpm --version >/dev/null 2>&1; then
+            corepack pnpm "$@"
+            return
+        fi
+    fi
+
+    if command -v pnpm >/dev/null 2>&1; then
+        pnpm "$@"
+        return
+    fi
+
+    echo "pnpm not found. Install pnpm globally, or use Node.js with Corepack enabled." >&2
+    exit 1
+}

--- a/web.sh
+++ b/web.sh
@@ -5,4 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/scripts/pnpm_cmd.sh"
 
-pnpm_cmd --filter landscape-webui dev "$@"
+(
+    cd "$SCRIPT_DIR"
+    pnpm_cmd --filter landscape-webui dev "$@"
+)

--- a/web.sh
+++ b/web.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 
-pnpm --filter landscape-webui dev "$@"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/scripts/pnpm_cmd.sh"
+
+pnpm_cmd --filter landscape-webui dev "$@"


### PR DESCRIPTION
## Summary
- harden the local build shell workflow with safer path handling, non-interactive defaults, and better pnpm/Corepack fallback behavior
- centralize OpenAPI/TypeScript generation and stage release static assets without relying on ignored source directories
- add and link a dedicated local build guide, clarifying release-style packaging versus day-to-day frontend builds

## Test plan
- Checked shell syntax with `bash -n`
- Verified `build.sh --list` works both from the repo root and when invoked via an absolute path from outside the repo
- Verified non-interactive default target selection by sourcing `build_env.sh` with stdin redirected from `/dev/null`

## 中文说明
### 变更摘要
- 加固本地构建脚本工作流，改进路径处理、非交互默认架构选择，以及 pnpm/Corepack 回退行为
- 统一 OpenAPI / TypeScript 生成流程，并将 release 静态资源整理为不依赖被忽略的源码目录
- 新增并链接本地构建说明，明确 release 式打包与日常前端构建的边界

### 验证
- 已用 `bash -n` 检查更新后的 shell 脚本语法
- 已验证 `build.sh --list` 在仓库根目录和仓库外通过绝对路径调用时都能正常工作
- 已验证在 stdin 重定向到 `/dev/null` 的非交互场景下，`build_env.sh` 会自动回退到默认目标架构