### PR TITLE
feat(ebpf): pass through ICMP in tproxy mode (#206)

### DIFF
--- a/dockerfiles/redirect_prog/Dockerfile
+++ b/dockerfiles/redirect_prog/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 # 安装必要的工具
 RUN apt-get update && apt-get install -y \
     iproute2 \
+    iptables \
     # tcpdump  \
     # curl  \
     && apt-get clean \

--- a/dockerfiles/redirect_prog/start.sh
+++ b/dockerfiles/redirect_prog/start.sh
@@ -7,6 +7,15 @@ ip route add local default dev lo table 100
 ip -6 rule add fwmark 0x1 lookup 106
 ip -6 route add local ::/0 dev lo table 106
 
+# ICMP passthrough (issue #206): the tproxy eBPF marks ICMP/ICMPv6 with 0x2 and
+# releases it to the routing stack instead of dropping it. Forward it out the
+# default route (WAN) and SNAT so replies come back symmetrically. TCP/UDP still
+# go through the TProxy listener untouched.
+echo 1 > /proc/sys/net/ipv4/ip_forward
+echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
+iptables -t nat -A POSTROUTING -m mark --mark 0x2/0x2 -j MASQUERADE
+ip6tables -t nat -A POSTROUTING -m mark --mark 0x2/0x2 -j MASQUERADE
+
 /app/server/run.sh /app/server &
 /app/redirect_pkg_handler &
 

--- a/landscape-ebpf/src/bpf/tproxy.bpf.c
+++ b/landscape-ebpf/src/bpf/tproxy.bpf.c
@@ -24,6 +24,15 @@ volatile const u8 proxy_ipv6_addr[16] = {0};
 volatile const __be32 proxy_addr = 0;
 volatile const __be16 proxy_port = 0;
 
+/* Mark applied to ICMP / ICMPv6 packets so they are released to the container
+ * routing stack instead of being sk_assign'd to the TProxy listener (which only
+ * has TCP/UDP sockets). Must avoid bit 0: start.sh installs
+ * `ip rule add fwmark 0x1/0x1 lookup 100` which locally delivers any mark whose
+ * bit 0 is set to the TProxy listener. 0x2 keeps ICMP out of that table so it
+ * follows the main route table; users match this mark with nft/iptables to
+ * forward it out the WAN. See issue #206. */
+#define LAND_TPROXY_ICMP_MARK 0x2
+
 static __always_inline int handle_pkg(struct __sk_buff *skb, struct packet_offset_info *offset,
                                       struct inet_pair *ip_pair, __be16 flow_port) {
 #define BPF_LOG_TOPIC "handle_pkg"
@@ -120,6 +129,11 @@ static __always_inline int is_tproxy_handle_protocol(const u8 protocol) {
     }
 }
 
+static __always_inline bool is_icmp_protocol(const u8 protocol) {
+    // IPPROTO_ICMP (1) for IPv4, NEXTHDR_ICMP (58 == IPPROTO_ICMPV6) for IPv6.
+    return protocol == IPPROTO_ICMP || protocol == NEXTHDR_ICMP;
+}
+
 SEC("tc/ingress")
 int tproxy_ingress(struct __sk_buff *skb) {
 #define BPF_LOG_TOPIC "tproxy_ingress"
@@ -149,6 +163,18 @@ int tproxy_ingress(struct __sk_buff *skb) {
     if (ret != TC_ACT_OK) {
         ld_bpf_log("is_tproxy_handle_protocol ret %d protocol: %u", ret, pkg_offset.l4_protocol);
         return ret;
+    }
+
+    /* TProxy binds only TCP/UDP sockets, so ICMP can never be sk_assign'd and
+     * would otherwise fall into the `!sk` branch of handle_pkg() and be dropped
+     * (TC_ACT_SHOT). Instead mark it and release it to the container routing
+     * stack (same as route_mode_ingress), letting the user's nft/iptables rules
+     * forward it out the WAN. This is what makes ping/traceroute work for
+     * devices steered into a TProxy container. See issue #206. */
+    if (is_icmp_protocol(pkg_offset.l4_protocol)) {
+        skb->mark = LAND_TPROXY_ICMP_MARK;
+        bpf_skb_change_type(skb, PACKET_HOST);
+        return TC_ACT_OK;
     }
 
     ret = read_tproxy_packet_info(skb, &pkg_offset, &ip_pair);


### PR DESCRIPTION
## 概述

修复 #206 描述的 ICMP 黑洞:被 **tproxy** flow 容器代理的设备无法 `ping`/`traceroute`(ICMP 100% 丢包),但 TCP/UDP 正常。

## 根因

`is_tproxy_handle_protocol()` 把 `IPPROTO_ICMP` / `NEXTHDR_ICMP` 也当成 tproxy 协议,于是 ICMP 进入 `handle_pkg()`。而那里只对 TCP/UDP 做 socket 查找,ICMP 的 `sk` 始终为 `NULL`,落入 `!sk` 分支 → `TC_ACT_SHOT`。被代理设备的每个 ICMP 包都在容器 veth ingress 被丢弃。

## 改动

在 `tproxy_ingress` 里识别 ICMP/ICMPv6,不再 `sk_assign`,而是打标后放行到容器路由栈(与 `route_mode_ingress` 一致):

```c
if (is_icmp_protocol(pkg_offset.l4_protocol)) {
    skb->mark = LAND_TPROXY_ICMP_MARK;   // 0x2
    bpf_skb_change_type(skb, PACKET_HOST);
    return TC_ACT_OK;
}
```

mark 用 `0x2` 以避开 bit 0 —— 示例 `start.sh` 的 `ip rule add fwmark 0x1/0x1 lookup 100`(tproxy 本地投递表)占用了 bit 0。之后用户用自己的 nft/iptables 规则把打标的 ICMP 转发出 WAN,契合 issue 里的方向(「将 icmp 数据打标后进行放行, 由用户的 nft 规则进行处理」)。

示例 redirect 镜像同步更新,做到开箱即用:
- `start.sh`:开启 `ip_forward` + `iptables -t nat -A POSTROUTING -m mark --mark 0x2/0x2 -j MASQUERADE`(v4 + v6)。
- `Dockerfile`:安装 `iptables`。

**TCP/UDP 的 tproxy 行为不变** —— ICMP 是唯一新增分支。这部分职责落在容器内运行的程序(handler + 镜像脚本),与 route 模式的思路一致。

## 行为变更

tproxy 下 ICMP 现在**经 WAN 直连**,而非被丢弃。因此 ping/traceroute 走的是 WAN 出口 IP 而非代理出口 —— 这正是 issue 的诉求(诊断能力优先于隐藏 IP)。TCP/UDP 仍走代理。

## 测试

kernel 7.0 上端到端验证,真实 Landscape 路由器 + docker tproxy 容器 + 经 `flow/rules`(netns 目标)导入的 LAN 客户端:

| | ICMP `ping` WAN 主机 | TCP HTTP 经代理 |
|---|---|---|
| **未打补丁(对照)** | 100% 丢包(bug) | 200 |
| **打补丁后** | 0% 丢包 ✅ | 200 ✅ |

- 内核 verifier 接受该程序(`tproxy_ingress` 加载 + JIT,挂到容器 veth ingress)。
- 容器 netns 内 `tcpdump` 确认 ICMP 被打标 `0x2`、经容器 MASQUERADE、**直连 WAN 出口**(不经 tproxy 处理程序);`tproxy处理程序` 日志仍显示 TCP 被代理(`[TCP] ... using DIRECT`)。
- 仅回退 eBPF 改动即可复现 100% ICMP 丢包。

Closes #206
