### PR TITLE
feat(flow): 为分流规则增加独立 name 字段

### DIFF
--- a/landscape-common/src/flow/config.rs
+++ b/landscape-common/src/flow/config.rs
@@ -23,6 +23,10 @@ pub struct FlowConfig {
     /// 处理流量目标网卡, 目前只取第一个
     /// 暂定, 可能会移动到具体的网卡上进行设置
     pub flow_targets: Vec<WeightedFlowTarget>,
+    /// 名称 (用于展示的简短标识, 为空时回退到 remark)
+    #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(required = false))]
+    pub name: String,
     /// 备注
     pub remark: String,
 

--- a/landscape-database/migration/src/lib.rs
+++ b/landscape-database/migration/src/lib.rs
@@ -48,6 +48,7 @@ mod m20260504_000000_flow_device_match;
 mod m20260620_000000_split_static_nat_v4_v6;
 mod m20260625_000000_enrolled_device_hostname;
 mod m20260721_000000_wan_pd_expected_len;
+mod m20260728_000000_add_name_in_flow;
 mod tables;
 
 pub struct Migrator;
@@ -104,6 +105,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260620_000000_split_static_nat_v4_v6::Migration),
             Box::new(m20260625_000000_enrolled_device_hostname::Migration),
             Box::new(m20260721_000000_wan_pd_expected_len::Migration),
+            Box::new(m20260728_000000_add_name_in_flow::Migration),
         ]
     }
 }

--- a/landscape-database/migration/src/m20260728_000000_add_name_in_flow.rs
+++ b/landscape-database/migration/src/m20260728_000000_add_name_in_flow.rs
@@ -1,0 +1,28 @@
+use sea_orm_migration::prelude::*;
+
+use crate::tables::flow_rule::FlowConfigs;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(FlowConfigs::Table)
+                    .add_column(ColumnDef::new(FlowConfigs::Name).string().not_null().default(""))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter().table(FlowConfigs::Table).drop_column(FlowConfigs::Name).to_owned(),
+            )
+            .await
+    }
+}

--- a/landscape-database/migration/src/tables/flow_rule.rs
+++ b/landscape-database/migration/src/tables/flow_rule.rs
@@ -8,6 +8,7 @@ pub enum FlowConfigs {
     FlowId,
     FlowMatchRules,
     PacketHandleIfaceName,
+    Name,
     Remark,
     UpdateAt,
 }

--- a/landscape-database/src/flow_rule/entity.rs
+++ b/landscape-database/src/flow_rule/entity.rs
@@ -22,6 +22,7 @@ pub struct Model {
     pub flow_match_rules: DBJson,
     #[sea_orm(column_type = "Json")]
     pub packet_handle_iface_name: DBJson,
+    pub name: String,
     pub remark: String,
     pub update_at: DBTimestamp,
 }
@@ -50,6 +51,7 @@ impl From<Model> for FlowConfig {
             flow_id: entity.flow_id,
             flow_match_rules: serde_json::from_value(entity.flow_match_rules).unwrap(),
             flow_targets: serde_json::from_value(entity.packet_handle_iface_name).unwrap(),
+            name: entity.name,
             remark: entity.remark,
             update_at: entity.update_at,
         }
@@ -71,6 +73,7 @@ impl UpdateActiveModel<ActiveModel> for FlowConfig {
         active.flow_match_rules = Set(serde_json::to_value(self.flow_match_rules).unwrap().into());
         active.packet_handle_iface_name =
             Set(serde_json::to_value(self.flow_targets).unwrap().into());
+        active.name = Set(self.name);
         active.remark = Set(self.remark);
         active.update_at = Set(self.update_at);
     }

--- a/landscape-database/src/rollback.rs
+++ b/landscape-database/src/rollback.rs
@@ -439,7 +439,7 @@ mod tests {
         assert_eq!(targets.first().unwrap().display_label, "current release boundary 0.21.0");
         assert_eq!(targets.get(1).unwrap().display_label, "previous release 0.20.1");
         assert_eq!(targets.get(2).unwrap().display_label, "older release 0.19.0");
-        assert_eq!(targets.first().unwrap().steps, 2);
+        assert_eq!(targets.first().unwrap().steps, 3);
     }
 
     #[test]
@@ -455,10 +455,11 @@ mod tests {
             .unwrap();
 
         let plan = build_rollback_plan(&current_state, &target, &all_migrations).unwrap();
-        assert_eq!(plan.steps, 5);
+        assert_eq!(plan.steps, 6);
         assert_eq!(
             plan.rollback_migrations,
             vec![
+                "m20260728_000000_add_name_in_flow".to_string(),
                 "m20260721_000000_wan_pd_expected_len".to_string(),
                 "m20260625_000000_enrolled_device_hostname".to_string(),
                 "m20260620_000000_split_static_nat_v4_v6".to_string(),

--- a/landscape-webui/src/components/flow/FlowConfigCard.vue
+++ b/landscape-webui/src/components/flow/FlowConfigCard.vue
@@ -38,10 +38,21 @@ async function del() {
     await refresh();
   }
 }
-const title_name = computed(() =>
-  props.config.remark == null || props.config.remark === ""
-    ? t("common.no_remark")
-    : frontEndStore.MASK_INFO(props.config.remark),
+const title_name = computed(() => {
+  if (props.config.name != null && props.config.name !== "") {
+    return frontEndStore.MASK_INFO(props.config.name);
+  }
+  if (props.config.remark != null && props.config.remark !== "") {
+    return frontEndStore.MASK_INFO(props.config.remark);
+  }
+  return t("common.no_remark");
+});
+const show_remark = computed(
+  () =>
+    props.config.name != null &&
+    props.config.name !== "" &&
+    props.config.remark != null &&
+    props.config.remark !== "",
 );
 </script>
 
@@ -141,11 +152,16 @@ const title_name = computed(() =>
       >
       </n-empty>
     </n-flex>
-    <n-flex v-else>
-      <FlowEntryRuleExhibit
-        v-for="item in config.flow_match_rules"
-        :rule="item"
-      ></FlowEntryRuleExhibit>
+    <n-flex v-else vertical>
+      <n-text v-if="show_remark" depth="3" style="font-size: 12px">
+        {{ frontEndStore.MASK_INFO(config.remark) }}
+      </n-text>
+      <n-flex>
+        <FlowEntryRuleExhibit
+          v-for="item in config.flow_match_rules"
+          :rule="item"
+        ></FlowEntryRuleExhibit>
+      </n-flex>
     </n-flex>
     <template #action>
       <n-tag v-for="each in config.flow_targets" :bordered="false">

--- a/landscape-webui/src/components/flow/FlowEditModal.vue
+++ b/landscape-webui/src/components/flow/FlowEditModal.vue
@@ -156,6 +156,13 @@ function normalizeFlowTargets(
             clearable
           />
         </n-form-item-gi>
+        <n-form-item-gi :span="3" :label="t('flow.edit.name')">
+          <n-input
+            :type="frontEndStore.presentation_mode ? 'password' : 'text'"
+            v-model:value="rule.name"
+            :placeholder="t('flow.edit.name_placeholder')"
+          />
+        </n-form-item-gi>
         <n-form-item-gi :span="5" :label="t('flow.edit.remark')">
           <n-input
             :type="frontEndStore.presentation_mode ? 'password' : 'text'"

--- a/landscape-webui/src/i18n/en/flow.ts
+++ b/landscape-webui/src/i18n/en/flow.ts
@@ -12,6 +12,8 @@ export default {
     title: "Flow Rule Editor",
     flow_id_label: "Flow ID",
     enabled: "Enabled",
+    name: "Name",
+    name_placeholder: "Short name shown as the card title",
     remark: "Remark",
     duplicate_id_warning:
       "**ID** cannot be -1 and must be unique, or it may overwrite existing rules",

--- a/landscape-webui/src/i18n/zh/flow.ts
+++ b/landscape-webui/src/i18n/zh/flow.ts
@@ -12,6 +12,8 @@ export default {
     title: "分流规则编辑",
     flow_id_label: "流 ID 标识",
     enabled: "启用",
+    name: "名称",
+    name_placeholder: "简短名称，用于卡片标题",
     remark: "备注",
     duplicate_id_warning: "**ID** 值不能为 -1, 且不能重复, 否则将会覆盖规则",
     duplicate_entry_warning: "入口匹配规则存在重复项: {dup}",

--- a/landscape-webui/src/lib/default_value.ts
+++ b/landscape-webui/src/lib/default_value.ts
@@ -6,6 +6,7 @@ export function flow_config_default(): FlowConfig {
     flow_id: -1,
     flow_match_rules: [],
     flow_targets: [],
+    name: "",
     remark: "",
   };
 }


### PR DESCRIPTION
### 背景 / 动机

关联 issue #209。

目前分流规则(`FlowConfig`)只有一个自由文本字段 `remark`,而 Web UI 的 `FlowConfigCard.vue`
直接把它当作卡片标题渲染(`flow_id: remark`)。由于没有独立的"说明"位置,想给一条 flow
记录用途/原因就只能塞进 `remark`,于是这个字段同时充当了"标题"和"说明"两个角色。

例如为了标记一条豁免规则不被误删,只能把整句原因写进名字,而它又会被当成卡片标题显示:

```
2: exempt k8s-wg1 (dedicated WG dialer) direct WAN - WG UDP needs it
```

标题和说明缺一个不可,却挤在同一个字段里。

### 改动内容

把"简短标题"和"详细说明"拆成两个字段:

- `FlowConfig` 新增 `name: String` 字段,带 `#[serde(default)]`,老数据/老客户端不传也能反序列化;
  utoipa schema 标记为非必填(生成的 TS 类型是 `name?: string`)。
- 数据库新增迁移 `m20260728_000000_add_name_in_flow`:
  `ALTER TABLE flow_configs ADD COLUMN name NOT NULL DEFAULT ''`。存量记录 `name` 置空,
  由前端回退逻辑保证行为不变;`down` 提供 `drop_column`(与既有迁移同范式,回滚未单独实测)。
- 前端:
  - 卡片标题优先显示 `name`,为空时回退 `remark`,再回退 `no_remark`(即老数据行为完全不变);
  - `name` 非空且 `remark` 非空时,`remark` 作为说明在卡片体内单独展示;
  - 编辑弹窗新增"名称"输入框(与 flow_id 同行);
  - `flow_config_default()` 补 `name: ""`。
- i18n:补充中英键 `flow.edit.name` / `flow.edit.name_placeholder`。

### 向后兼容

- API:`name` 非必填,老客户端提交不带 `name` 的请求正常工作。
- 数据:迁移给存量行填空字符串,标题回退到 `remark`,升级后观感零变化。
- 展示层没有强制要求填 `name`;不填时和现在完全一样。

### 测试

在本地 Linux(Rust + eBPF 工具链齐全)实测:

- `cargo check -p landscape-common -p landscape-database` 通过。
- `cargo test -p landscape-common`:151 passed。
- `cargo test -p landscape-database`:26 passed / 1 failed —— 唯一失败的是下文"已知事项"里那个
  在 main 上就已失败的 pre-existing 测试,与本 PR 无关;迁移 `ALTER TABLE flow_configs ADD COLUMN name`
  实际应用成功。
- `gen_ts_bindings.sh --force`:OpenAPI 导出 + orval 生成通过,确认 `FlowConfig.name` 进入
  schema 且为可选字段。
- 前端 `pnpm build`(vue-tsc 类型检查 + vite):通过。

### 已知事项 / 需要维护者留意

- `landscape-database` 有 **1 个测试在改动前(当前 main)就已失败**:
  `rollback::tests::rollback_targets_are_computed_from_current_head`
  —— 在干净的 main 上 `git stash && cargo test -p landscape-database rollback::` 即可复现,
  失败原因是该快照测试的断言未随 `m20260625_..._enrolled_device_hostname` 更新(head 越过了
  0.21.0 边界),与本 PR 无关。
- 本 PR **只更新了因为新增迁移而失效的那个快照测试**
  `rollback::tests::rollback_plan_lists_migrations_in_reverse_order`(补上新的迁移名、步数 4→5),
  保证本 PR 不引入新的测试失败;上面那个 pre-existing 失败保持原样未动,因为修它需要就
  release boundary 语义做判断,更适合单独处理。
