### PR TITLE
feat(metric): 聚合查询端点 + conn_summaries 独立保留控制

### DIFF
--- a/landscape-common/src/concurrency.rs
+++ b/landscape-common/src/concurrency.rs
@@ -153,6 +153,8 @@ pub mod task_label {
         pub const METRIC_DNS_SUMMARY: &str = "metric.dns_summary";
         /// Query lightweight DNS summary statistics.
         pub const METRIC_DNS_LIGHTWEIGHT_SUMMARY: &str = "metric.dns_lightweight_summary";
+        /// Query bounded-cardinality connection aggregates.
+        pub const METRIC_CONNECT_AGGREGATES: &str = "metric.connect_aggregates";
     }
 }
 

--- a/landscape-common/src/config/loader.rs
+++ b/landscape-common/src/config/loader.rs
@@ -182,6 +182,11 @@ impl RuntimeConfig {
             ),
         };
 
+        let connect_1d_retention_days = config
+            .metric
+            .connect_1d_retention_days
+            .unwrap_or(crate::DEFAULT_METRIC_CONNECT_1D_RETENTION_DAYS);
+
         let metric = MetricRuntimeConfig {
             mode: config.metric.mode.clone().unwrap_or(crate::DEFAULT_METRIC_MODE),
             connect_second_window_minutes: config
@@ -196,14 +201,19 @@ impl RuntimeConfig {
                 .metric
                 .connect_1h_retention_days
                 .unwrap_or(crate::DEFAULT_METRIC_CONNECT_1H_RETENTION_DAYS),
-            connect_1d_retention_days: config
-                .metric
-                .connect_1d_retention_days
-                .unwrap_or(crate::DEFAULT_METRIC_CONNECT_1D_RETENTION_DAYS),
+            connect_1d_retention_days,
             connect_aggregate_retention_days: config
                 .metric
                 .connect_aggregate_retention_days
                 .unwrap_or(crate::DEFAULT_METRIC_CONNECT_AGGREGATE_RETENTION_DAYS),
+            connect_summary_retention_days: config
+                .metric
+                .connect_summary_retention_days
+                .unwrap_or(connect_1d_retention_days),
+            connect_summary_max_rows: config
+                .metric
+                .connect_summary_max_rows
+                .unwrap_or(crate::DEFAULT_METRIC_CONNECT_SUMMARY_MAX_ROWS),
             dns_retention_days: config
                 .metric
                 .dns_retention_days

--- a/landscape-common/src/config/loader.rs
+++ b/landscape-common/src/config/loader.rs
@@ -200,6 +200,10 @@ impl RuntimeConfig {
                 .metric
                 .connect_1d_retention_days
                 .unwrap_or(crate::DEFAULT_METRIC_CONNECT_1D_RETENTION_DAYS),
+            connect_aggregate_retention_days: config
+                .metric
+                .connect_aggregate_retention_days
+                .unwrap_or(crate::DEFAULT_METRIC_CONNECT_AGGREGATE_RETENTION_DAYS),
             dns_retention_days: config
                 .metric
                 .dns_retention_days

--- a/landscape-common/src/config/runtime.rs
+++ b/landscape-common/src/config/runtime.rs
@@ -65,6 +65,8 @@ pub struct MetricRuntimeConfig {
     pub connect_1h_retention_days: u64,
     pub connect_1d_retention_days: u64,
     pub connect_aggregate_retention_days: u64,
+    pub connect_summary_retention_days: u64,
+    pub connect_summary_max_rows: u64,
     pub dns_retention_days: u64,
     pub write_batch_size: usize,
     pub write_flush_interval_secs: u64,
@@ -146,6 +148,8 @@ impl RuntimeConfig {
          Connect 1h Retention: {} days\n\
          Connect 1d Retention: {} days\n\
          Connect Aggregate Retention: {} days\n\
+         Connect Summary Retention: {} days\n\
+         Connect Summary Max Rows: {}\n\
          DNS Retention: {} days\n\
          Write Batch Size: {}\n\
          Write Flush Interval: {}s\n\
@@ -179,6 +183,8 @@ impl RuntimeConfig {
             self.metric.connect_1h_retention_days,
             self.metric.connect_1d_retention_days,
             self.metric.connect_aggregate_retention_days,
+            self.metric.connect_summary_retention_days,
+            self.metric.connect_summary_max_rows,
             self.metric.dns_retention_days,
             self.metric.write_batch_size,
             self.metric.write_flush_interval_secs,
@@ -216,6 +222,12 @@ impl MetricRuntimeConfig {
         }
         if let Some(v) = config.connect_aggregate_retention_days {
             self.connect_aggregate_retention_days = v;
+        }
+        if let Some(v) = config.connect_summary_retention_days {
+            self.connect_summary_retention_days = v;
+        }
+        if let Some(v) = config.connect_summary_max_rows {
+            self.connect_summary_max_rows = v;
         }
         if let Some(v) = config.dns_retention_days {
             self.dns_retention_days = v;

--- a/landscape-common/src/config/runtime.rs
+++ b/landscape-common/src/config/runtime.rs
@@ -64,6 +64,7 @@ pub struct MetricRuntimeConfig {
     pub connect_1m_retention_days: u64,
     pub connect_1h_retention_days: u64,
     pub connect_1d_retention_days: u64,
+    pub connect_aggregate_retention_days: u64,
     pub dns_retention_days: u64,
     pub write_batch_size: usize,
     pub write_flush_interval_secs: u64,
@@ -144,6 +145,7 @@ impl RuntimeConfig {
          Connect 1m Retention: {} days\n\
          Connect 1h Retention: {} days\n\
          Connect 1d Retention: {} days\n\
+         Connect Aggregate Retention: {} days\n\
          DNS Retention: {} days\n\
          Write Batch Size: {}\n\
          Write Flush Interval: {}s\n\
@@ -176,6 +178,7 @@ impl RuntimeConfig {
             self.metric.connect_1m_retention_days,
             self.metric.connect_1h_retention_days,
             self.metric.connect_1d_retention_days,
+            self.metric.connect_aggregate_retention_days,
             self.metric.dns_retention_days,
             self.metric.write_batch_size,
             self.metric.write_flush_interval_secs,
@@ -210,6 +213,9 @@ impl MetricRuntimeConfig {
         }
         if let Some(v) = config.connect_1d_retention_days {
             self.connect_1d_retention_days = v;
+        }
+        if let Some(v) = config.connect_aggregate_retention_days {
+            self.connect_aggregate_retention_days = v;
         }
         if let Some(v) = config.dns_retention_days {
             self.dns_retention_days = v;

--- a/landscape-common/src/config/settings.rs
+++ b/landscape-common/src/config/settings.rs
@@ -81,6 +81,12 @@ pub struct LandscapeMetricConfig {
     pub connect_aggregate_retention_days: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(required = false, nullable = false))]
+    pub connect_summary_retention_days: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(required = false, nullable = false))]
+    pub connect_summary_max_rows: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(required = false, nullable = false))]
     pub dns_retention_days: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(required = false, nullable = false))]

--- a/landscape-common/src/config/settings.rs
+++ b/landscape-common/src/config/settings.rs
@@ -78,6 +78,9 @@ pub struct LandscapeMetricConfig {
     pub connect_1d_retention_days: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(required = false, nullable = false))]
+    pub connect_aggregate_retention_days: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(required = false, nullable = false))]
     pub dns_retention_days: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(required = false, nullable = false))]

--- a/landscape-common/src/lib.rs
+++ b/landscape-common/src/lib.rs
@@ -82,6 +82,7 @@ pub const DEFAULT_DNS_METRIC_RETENTION_DAYS: u64 = 7;
 /// long horizon cheap, which is what lets connection detail be kept briefly.
 pub const DEFAULT_METRIC_CONNECT_AGGREGATE_RETENTION_DAYS: u64 = 90;
 pub const DEFAULT_METRIC_CONNECT_SECOND_WINDOW_MINUTES: u64 = 5;
+pub const DEFAULT_METRIC_CONNECT_SUMMARY_MAX_ROWS: u64 = 0;
 
 // Metric Performance & Storage Defaults
 pub const DEFAULT_METRIC_WRITE_BATCH_SIZE: usize = 20_000;

--- a/landscape-common/src/lib.rs
+++ b/landscape-common/src/lib.rs
@@ -77,6 +77,10 @@ pub const DEFAULT_METRIC_CONNECT_1M_RETENTION_DAYS: u64 = 1;
 pub const DEFAULT_METRIC_CONNECT_1H_RETENTION_DAYS: u64 = 7;
 pub const DEFAULT_METRIC_CONNECT_1D_RETENTION_DAYS: u64 = 30;
 pub const DEFAULT_DNS_METRIC_RETENTION_DAYS: u64 = 7;
+/// The aggregate tier is keyed by (bucket, src_ip, proto, dst_port) rather than by
+/// connection, so its row count does not grow with connection volume. That makes a
+/// long horizon cheap, which is what lets connection detail be kept briefly.
+pub const DEFAULT_METRIC_CONNECT_AGGREGATE_RETENTION_DAYS: u64 = 90;
 pub const DEFAULT_METRIC_CONNECT_SECOND_WINDOW_MINUTES: u64 = 5;
 
 // Metric Performance & Storage Defaults

--- a/landscape-common/src/metric/connect.rs
+++ b/landscape-common/src/metric/connect.rs
@@ -294,3 +294,43 @@ pub struct MetricChartRequest {
     #[cfg_attr(feature = "openapi", schema(nullable = false))]
     pub resolution: Option<MetricResolution>,
 }
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum AggregateGroupBy {
+    #[default]
+    SrcIp,
+    DstPort,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema, utoipa::IntoParams))]
+#[cfg_attr(feature = "openapi", into_params(parameter_in = Query))]
+pub struct ConnectAggregateQueryParams {
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub start_time: Option<u64>,
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub end_time: Option<u64>,
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub group_by: Option<AggregateGroupBy>,
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub src_ip: Option<String>,
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub dst_port: Option<u16>,
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub l4_proto: Option<u8>,
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ConnectAggregatePoint {
+    pub group_key: String,
+    pub ingress_bytes: u64,
+    pub ingress_packets: u64,
+    pub egress_bytes: u64,
+    pub egress_packets: u64,
+    pub conn_count: u64,
+}

--- a/landscape-webserver/src/metrics/mod.rs
+++ b/landscape-webserver/src/metrics/mod.rs
@@ -1,9 +1,10 @@
 use axum::extract::{Query, State};
 use landscape_common::api_response::LandscapeApiResp as CommonApiResp;
 use landscape_common::metric::connect::{
-    ConnectGlobalStats, ConnectHistoryQueryParams, ConnectHistoryStatus, ConnectMetricPoint,
-    ConnectRealtimeStatus, GetConnectGlobalStatsParams, IfaceRealtimeStat, IpHistoryStat,
-    IpRealtimeStat, MetricChartRequest,
+    ConnectAggregatePoint, ConnectAggregateQueryParams, ConnectGlobalStats,
+    ConnectHistoryQueryParams, ConnectHistoryStatus, ConnectMetricPoint, ConnectRealtimeStatus,
+    GetConnectGlobalStatsParams, IfaceRealtimeStat, IpHistoryStat, IpRealtimeStat,
+    MetricChartRequest,
 };
 use landscape_common::metric::dns::{
     DnsHistoryQueryParams, DnsHistoryResponse, DnsLightweightSummaryResponse,
@@ -25,6 +26,7 @@ pub fn get_metric_paths() -> OpenApiRouter<LandscapeApp> {
         .routes(routes!(get_connect_metric_info))
         .routes(routes!(get_connect_history))
         .routes(routes!(get_connect_global_stats))
+        .routes(routes!(get_connect_aggregates))
         .routes(routes!(get_iface_stats))
         .routes(routes!(get_src_ip_stats))
         .routes(routes!(get_dst_ip_stats))
@@ -121,6 +123,22 @@ async fn get_connect_global_stats(
     Query(params): Query<GetConnectGlobalStatsParams>,
 ) -> LandscapeApiResult<ConnectGlobalStats> {
     let data = state.metric_service.get_global_stats(params.force_refresh.unwrap_or(false)).await?;
+    LandscapeApiResp::success(data)
+}
+
+#[utoipa::path(
+    get,
+    path = "/connections/aggregates",
+    tag = "Metric",
+    operation_id = "get_connect_aggregates",
+    params(ConnectAggregateQueryParams),
+    responses((status = 200, body = CommonApiResp<Vec<ConnectAggregatePoint>>))
+)]
+async fn get_connect_aggregates(
+    State(state): State<LandscapeApp>,
+    Query(params): Query<ConnectAggregateQueryParams>,
+) -> LandscapeApiResult<Vec<ConnectAggregatePoint>> {
+    let data = state.metric_service.query_connection_aggregates(params).await;
     LandscapeApiResp::success(data)
 }
 

--- a/landscape-webserver/src/openapi.rs
+++ b/landscape-webserver/src/openapi.rs
@@ -117,6 +117,7 @@ impl Modify for SecurityAddon {
         // Schemas referenced by IntoParams but not auto-registered
         landscape_common::metric::connect::ConnectSortKey,
         landscape_common::metric::connect::SortOrder,
+        landscape_common::metric::connect::AggregateGroupBy,
         landscape_common::metric::dns::DnsSortKey,
         landscape_common::metric::dns::DnsOutcome,
         landscape_common::dns::rule::LandscapeDnsRecordType,

--- a/landscape-webui/src/components/metric/connect/history/HistoryConnectChart.vue
+++ b/landscape-webui/src/components/metric/connect/history/HistoryConnectChart.vue
@@ -157,6 +157,7 @@ onMounted(fetchData);
           v-for="opt in resolutionOptions"
           :key="opt.value"
           :value="opt.value"
+          :disabled="opt.disabled"
         >
           {{ opt.label }}
         </n-radio-button>

--- a/landscape-webui/src/components/metric/connect/history/HistoryConnectChart.vue
+++ b/landscape-webui/src/components/metric/connect/history/HistoryConnectChart.vue
@@ -36,11 +36,28 @@ const resolution = ref<MetricResolution>(
   })(),
 );
 
+// A connection that never spanned a coarser bucket has no rows at that
+// resolution, so offering it would only ever render an empty chart.
+const spanMs = computed(() => {
+  const start =
+    props.createTimeMs || Number(props.conn.create_time) / 1_000_000;
+  const end = props.lastReportTime || Date.now();
+  return Math.max(0, end - start);
+});
+
 const resolutionOptions = computed(() => [
   { label: t("metric.connect.chart.second_level"), value: "second" },
   { label: t("metric.connect.chart.minute_level"), value: "minute" },
-  { label: t("metric.connect.chart.hour_level"), value: "hour" },
-  { label: t("metric.connect.chart.day_level"), value: "day" },
+  {
+    label: t("metric.connect.chart.hour_level"),
+    value: "hour",
+    disabled: spanMs.value < 3600 * 1000,
+  },
+  {
+    label: t("metric.connect.chart.day_level"),
+    value: "day",
+    disabled: spanMs.value < 24 * 3600 * 1000,
+  },
 ]);
 
 async function fetchData() {

--- a/landscape-webui/src/i18n/en/config/index.ts
+++ b/landscape-webui/src/i18n/en/config/index.ts
@@ -51,6 +51,13 @@ export default {
   conn_retention_day_days: "Aggregated Data (Day)",
   conn_retention_day_days_desc:
     "Retention period for daily aggregated connection metrics in days",
+  conn_detail_settings: "Connection Detail Settings",
+  conn_summary_retention_days: "Detail Retention (Days)",
+  conn_summary_retention_days_desc:
+    "Retention period for per-connection detail summary rows in days",
+  conn_summary_max_rows: "Detail Row Cap",
+  conn_summary_max_rows_desc:
+    "Maximum number of detail summary rows kept per connection (0 = unlimited)",
   dns_retention_days: "DNS Retention (Days)",
   dns_retention_days_desc:
     "Retention period for DNS query logs and metrics in days",

--- a/landscape-webui/src/i18n/zh/config/index.ts
+++ b/landscape-webui/src/i18n/zh/config/index.ts
@@ -45,6 +45,11 @@ export default {
   conn_retention_hour_days_desc: "按小时聚合的连接指标保存期限（天）",
   conn_retention_day_days: "聚合数据保存 (天级)",
   conn_retention_day_days_desc: "按天聚合的连接指标保存期限（天）",
+  conn_detail_settings: "连接明细设置",
+  conn_summary_retention_days: "明细保存天数",
+  conn_summary_retention_days_desc: "单连接明细汇总行的保存期限（天）",
+  conn_summary_max_rows: "明细行数上限",
+  conn_summary_max_rows_desc: "每条连接保留的最大明细汇总行数（0 = 不限制）",
   dns_retention_days: "DNS 数据保存天数",
   dns_retention_days_desc: "DNS 查询日志和指标的保存期限（天）",
 

--- a/landscape-webui/src/stores/metric_config.ts
+++ b/landscape-webui/src/stores/metric_config.ts
@@ -11,6 +11,8 @@ export const useMetricConfigStore = defineStore("metric_config", () => {
   const connect1mRetentionDays = ref<number | undefined>(undefined);
   const connect1hRetentionDays = ref<number | undefined>(undefined);
   const connect1dRetentionDays = ref<number | undefined>(undefined);
+  const connectSummaryRetentionDays = ref<number | undefined>(undefined);
+  const connectSummaryMaxRows = ref<number | undefined>(undefined);
   const dnsRetentionDays = ref<number | undefined>(undefined);
   const writeBatchSize = ref<number | undefined>(undefined);
   const writeFlushIntervalSecs = ref<number | undefined>(undefined);
@@ -32,6 +34,9 @@ export const useMetricConfigStore = defineStore("metric_config", () => {
       metric.connect_1h_retention_days ?? undefined;
     connect1dRetentionDays.value =
       metric.connect_1d_retention_days ?? undefined;
+    connectSummaryRetentionDays.value =
+      metric.connect_summary_retention_days ?? undefined;
+    connectSummaryMaxRows.value = metric.connect_summary_max_rows ?? undefined;
     dnsRetentionDays.value = metric.dns_retention_days ?? undefined;
     writeBatchSize.value = metric.write_batch_size ?? undefined;
     writeFlushIntervalSecs.value =
@@ -52,6 +57,8 @@ export const useMetricConfigStore = defineStore("metric_config", () => {
       connect_1m_retention_days: connect1mRetentionDays.value,
       connect_1h_retention_days: connect1hRetentionDays.value,
       connect_1d_retention_days: connect1dRetentionDays.value,
+      connect_summary_retention_days: connectSummaryRetentionDays.value,
+      connect_summary_max_rows: connectSummaryMaxRows.value,
       dns_retention_days: dnsRetentionDays.value,
       write_batch_size: writeBatchSize.value,
       write_flush_interval_secs: writeFlushIntervalSecs.value,
@@ -77,6 +84,8 @@ export const useMetricConfigStore = defineStore("metric_config", () => {
     connect1mRetentionDays,
     connect1hRetentionDays,
     connect1dRetentionDays,
+    connectSummaryRetentionDays,
+    connectSummaryMaxRows,
     dnsRetentionDays,
     writeBatchSize,
     writeFlushIntervalSecs,

--- a/landscape-webui/src/views/config_parts/MetricConfigCard.vue
+++ b/landscape-webui/src/views/config_parts/MetricConfigCard.vue
@@ -109,6 +109,40 @@ async function handleSaveMetric() {
       </n-grid>
 
       <n-divider title-placement="left">
+        {{ t("config.conn_detail_settings") }}
+      </n-divider>
+      <n-grid x-gap="12" :cols="2">
+        <n-gi>
+          <n-form-item :label="t('config.conn_summary_retention_days')">
+            <n-input-number
+              v-model:value="metricStore.connectSummaryRetentionDays"
+              :min="1"
+              :max="3650"
+              placeholder="30"
+              style="width: 100%"
+            />
+            <template #feedback>
+              {{ t("config.conn_summary_retention_days_desc") }}
+            </template>
+          </n-form-item>
+        </n-gi>
+        <n-gi>
+          <n-form-item :label="t('config.conn_summary_max_rows')">
+            <n-input-number
+              v-model:value="metricStore.connectSummaryMaxRows"
+              :min="0"
+              :max="100000000"
+              placeholder="0"
+              style="width: 100%"
+            />
+            <template #feedback>
+              {{ t("config.conn_summary_max_rows_desc") }}
+            </template>
+          </n-form-item>
+        </n-gi>
+      </n-grid>
+
+      <n-divider title-placement="left">
         {{ t("config.dns_retention_days") }}
       </n-divider>
       <n-form-item :label="t('config.dns_retention_days')">

--- a/landscape/src/metric/duckdb/connect/cleanup.rs
+++ b/landscape/src/metric/duckdb/connect/cleanup.rs
@@ -6,6 +6,7 @@ pub struct CleanupStats {
     pub deleted_1m: usize,
     pub deleted_1h: usize,
     pub deleted_1d: usize,
+    pub deleted_aggregate: usize,
     pub deleted_iface_5s: usize,
     pub budget_hit: bool,
     pub elapsed_ms: u128,
@@ -66,6 +67,7 @@ pub fn cleanup_old_cold_metrics_only(
     cutoff_1m: u64,
     cutoff_1h: u64,
     cutoff_1d: u64,
+    cutoff_aggregate: u64,
     cleanup_time_budget_ms: u64,
     cleanup_slice_window_secs: u64,
 ) -> CleanupStats {
@@ -130,6 +132,21 @@ pub fn cleanup_old_cold_metrics_only(
         deadline,
     );
     stats.deleted_1d = deleted_1d;
+    stats.budget_hit = budget_hit;
+    if stats.budget_hit {
+        stats.elapsed_ms = start.elapsed().as_millis();
+        return stats;
+    }
+
+    let (deleted_aggregate, budget_hit) = delete_table_in_slices(
+        conn,
+        "conn_aggregates_1h",
+        "report_time",
+        cutoff_aggregate,
+        slice_window_ms,
+        deadline,
+    );
+    stats.deleted_aggregate = deleted_aggregate;
     stats.budget_hit = budget_hit;
     stats.elapsed_ms = start.elapsed().as_millis();
     stats

--- a/landscape/src/metric/duckdb/connect/query.rs
+++ b/landscape/src/metric/duckdb/connect/query.rs
@@ -1,5 +1,8 @@
 use duckdb::{params, Connection};
-use landscape_common::metric::connect::{ConnectKey, ConnectMetricPoint, MetricResolution};
+use landscape_common::metric::connect::{
+    AggregateGroupBy, ConnectAggregatePoint, ConnectAggregateQueryParams, ConnectKey,
+    ConnectMetricPoint, MetricResolution,
+};
 
 pub fn query_metric_by_key(
     conn: &Connection,
@@ -59,5 +62,205 @@ pub fn query_metric_by_key(
             tracing::error!("failed to execute query_metric_by_key: {}", error);
             Vec::new()
         }
+    }
+}
+
+pub fn query_connection_aggregates(
+    conn: &Connection,
+    params: ConnectAggregateQueryParams,
+) -> Vec<ConnectAggregatePoint> {
+    let group_by = params.group_by.unwrap_or_default();
+    let group_col = match group_by {
+        AggregateGroupBy::SrcIp => "src_ip",
+        AggregateGroupBy::DstPort => "CAST(dst_port AS VARCHAR)",
+    };
+
+    let mut conditions: Vec<String> = Vec::new();
+
+    if params.start_time.is_some() {
+        conditions.push("report_time >= ?".into());
+    }
+    if params.end_time.is_some() {
+        conditions.push("report_time < ?".into());
+    }
+    if params.src_ip.is_some() {
+        conditions.push("src_ip = ?".into());
+    }
+    if params.l4_proto.is_some() {
+        conditions.push("l4_proto = ?".into());
+    }
+    if params.dst_port.is_some() {
+        conditions.push("dst_port = ?".into());
+    }
+
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
+    };
+
+    let limit = params.limit.unwrap_or(100).min(1000);
+
+    let sql = format!(
+        "SELECT {group_col} AS group_key,
+                SUM(ingress_bytes) AS ingress_bytes,
+                SUM(ingress_packets) AS ingress_packets,
+                SUM(egress_bytes) AS egress_bytes,
+                SUM(egress_packets) AS egress_packets,
+                SUM(conn_count) AS conn_count
+         FROM conn_aggregates_1h
+         {where_clause}
+         GROUP BY group_key
+         ORDER BY (SUM(ingress_bytes) + SUM(egress_bytes)) DESC
+         LIMIT ?"
+    );
+
+    let mut stmt = match conn.prepare(&sql) {
+        Ok(stmt) => stmt,
+        Err(error) => {
+            tracing::error!("failed to prepare query_connection_aggregates: {}", error);
+            return Vec::new();
+        }
+    };
+
+    let mut bind_params: Vec<Box<dyn duckdb::ToSql>> = Vec::new();
+    if let Some(start) = params.start_time {
+        bind_params.push(Box::new(start as i64));
+    }
+    if let Some(end) = params.end_time {
+        bind_params.push(Box::new(end as i64));
+    }
+    if let Some(ref src_ip) = params.src_ip {
+        bind_params.push(Box::new(src_ip.clone()));
+    }
+    if let Some(proto) = params.l4_proto {
+        bind_params.push(Box::new(proto as i64));
+    }
+    if let Some(port) = params.dst_port {
+        bind_params.push(Box::new(port as i64));
+    }
+    bind_params.push(Box::new(limit as i64));
+
+    let param_refs: Vec<&dyn duckdb::ToSql> = bind_params.iter().map(|b| b.as_ref()).collect();
+
+    let rows = stmt.query_map(param_refs.as_slice(), |row| {
+        Ok(ConnectAggregatePoint {
+            group_key: row.get(0)?,
+            ingress_bytes: row.get::<_, i64>(1)? as u64,
+            ingress_packets: row.get::<_, i64>(2)? as u64,
+            egress_bytes: row.get::<_, i64>(3)? as u64,
+            egress_packets: row.get::<_, i64>(4)? as u64,
+            conn_count: row.get::<_, i64>(5)? as u64,
+        })
+    });
+
+    match rows {
+        Ok(rows) => rows.filter_map(Result::ok).collect(),
+        Err(error) => {
+            tracing::error!("failed to execute query_connection_aggregates: {}", error);
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metric::duckdb::connect::schema::{
+        create_metrics_table, upsert_aggregate_bucket_values, AggregateBucketWrite,
+    };
+    use duckdb::Connection;
+
+    fn seed_aggregates(conn: &Connection) {
+        create_metrics_table(conn).unwrap();
+        for (ip, port, ib) in
+            [("192.168.1.10", 443, 1000u64), ("192.168.1.10", 80, 500), ("192.168.1.20", 443, 2000)]
+        {
+            upsert_aggregate_bucket_values(
+                conn,
+                &AggregateBucketWrite {
+                    report_time: 3_600_000,
+                    src_ip: ip.to_string(),
+                    l4_proto: 6,
+                    dst_port: port,
+                    ingress_bytes: ib,
+                    ingress_packets: 10,
+                    egress_bytes: ib / 2,
+                    egress_packets: 5,
+                    conn_count: 1,
+                },
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn query_aggregates_group_by_src_ip() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed_aggregates(&conn);
+
+        let results = query_connection_aggregates(
+            &conn,
+            ConnectAggregateQueryParams {
+                group_by: Some(AggregateGroupBy::SrcIp),
+                ..Default::default()
+            },
+        );
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].group_key, "192.168.1.20");
+        assert_eq!(results[0].ingress_bytes, 2000);
+        assert_eq!(results[1].group_key, "192.168.1.10");
+        assert_eq!(results[1].ingress_bytes, 1500);
+    }
+
+    #[test]
+    fn query_aggregates_group_by_dst_port() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed_aggregates(&conn);
+
+        let results = query_connection_aggregates(
+            &conn,
+            ConnectAggregateQueryParams {
+                group_by: Some(AggregateGroupBy::DstPort),
+                ..Default::default()
+            },
+        );
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].group_key, "443");
+        assert_eq!(results[0].ingress_bytes, 3000);
+    }
+
+    #[test]
+    fn query_aggregates_with_src_ip_filter() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed_aggregates(&conn);
+
+        let results = query_connection_aggregates(
+            &conn,
+            ConnectAggregateQueryParams {
+                group_by: Some(AggregateGroupBy::DstPort),
+                src_ip: Some("192.168.1.10".to_string()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].ingress_bytes, 1000);
+        assert_eq!(results[0].group_key, "443");
+    }
+
+    #[test]
+    fn query_aggregates_respects_limit() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed_aggregates(&conn);
+
+        let results = query_connection_aggregates(
+            &conn,
+            ConnectAggregateQueryParams {
+                group_by: Some(AggregateGroupBy::SrcIp),
+                limit: Some(1),
+                ..Default::default()
+            },
+        );
+        assert_eq!(results.len(), 1);
     }
 }

--- a/landscape/src/metric/duckdb/connect/schema.rs
+++ b/landscape/src/metric/duckdb/connect/schema.rs
@@ -142,7 +142,106 @@ pub fn create_metrics_table(conn: &Connection) -> duckdb::Result<()> {
             active_conns INTEGER,
             PRIMARY KEY (ifindex, report_time)
         );
+
+        CREATE TABLE IF NOT EXISTS conn_aggregates_1h (
+            report_time BIGINT,
+            src_ip TEXT,
+            l4_proto INTEGER,
+            dst_port INTEGER,
+            ingress_bytes BIGINT,
+            ingress_packets BIGINT,
+            egress_bytes BIGINT,
+            egress_packets BIGINT,
+            conn_count BIGINT,
+            PRIMARY KEY (report_time, src_ip, l4_proto, dst_port)
+        );
     ";
 
     conn.execute_batch(sql)
+}
+
+/// One row of the bounded-cardinality aggregate tier, ready to persist.
+#[derive(Debug, Clone, Default)]
+pub struct AggregateBucketWrite {
+    pub report_time: u64,
+    pub src_ip: String,
+    pub l4_proto: u8,
+    pub dst_port: u16,
+    pub ingress_bytes: u64,
+    pub ingress_packets: u64,
+    pub egress_bytes: u64,
+    pub egress_packets: u64,
+    pub conn_count: u64,
+}
+
+/// Fold one aggregate bucket into conn_aggregates_1h.
+///
+/// Unlike the per-connection cold tables, this key is shared by many connections,
+/// so the counters must ADD. GREATEST would silently keep only the largest
+/// contributor and drop the rest of the traffic.
+pub fn upsert_aggregate_bucket_values(
+    conn: &Connection,
+    w: &AggregateBucketWrite,
+) -> duckdb::Result<usize> {
+    conn.execute(
+        "
+        INSERT INTO conn_aggregates_1h (
+            report_time, src_ip, l4_proto, dst_port,
+            ingress_bytes, ingress_packets, egress_bytes, egress_packets, conn_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        ON CONFLICT (report_time, src_ip, l4_proto, dst_port) DO UPDATE SET
+            ingress_bytes   = conn_aggregates_1h.ingress_bytes   + EXCLUDED.ingress_bytes,
+            ingress_packets = conn_aggregates_1h.ingress_packets + EXCLUDED.ingress_packets,
+            egress_bytes    = conn_aggregates_1h.egress_bytes    + EXCLUDED.egress_bytes,
+            egress_packets  = conn_aggregates_1h.egress_packets  + EXCLUDED.egress_packets,
+            conn_count      = conn_aggregates_1h.conn_count      + EXCLUDED.conn_count
+        ",
+        params![
+            w.report_time as i64,
+            w.src_ip.as_str(),
+            w.l4_proto as i64,
+            w.dst_port as i64,
+            w.ingress_bytes as i64,
+            w.ingress_packets as i64,
+            w.egress_bytes as i64,
+            w.egress_packets as i64,
+            w.conn_count as i64,
+        ],
+    )
+}
+
+#[cfg(test)]
+mod aggregate_tests {
+    use super::*;
+
+    fn write(report_time: u64, ib: u64, eb: u64, cc: u64) -> AggregateBucketWrite {
+        AggregateBucketWrite {
+            report_time,
+            src_ip: "192.168.100.20".to_string(),
+            l4_proto: 6,
+            dst_port: 443,
+            ingress_bytes: ib,
+            ingress_packets: 1,
+            egress_bytes: eb,
+            egress_packets: 1,
+            conn_count: cc,
+        }
+    }
+
+    #[test]
+    fn accumulates_across_connections() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_metrics_table(&conn).unwrap();
+        upsert_aggregate_bucket_values(&conn, &write(3_600_000, 100, 200, 1)).unwrap();
+        upsert_aggregate_bucket_values(&conn, &write(3_600_000, 300, 400, 1)).unwrap();
+        let row: (i64, i64, i64) = conn
+            .query_row(
+                "SELECT ingress_bytes, egress_bytes, conn_count FROM conn_aggregates_1h
+                 WHERE report_time = ?1",
+                params![3_600_000i64],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(row, (400, 600, 2), "cross-connection counters must add, not max");
+    }
 }

--- a/landscape/src/metric/duckdb/hot_sqlite.rs
+++ b/landscape/src/metric/duckdb/hot_sqlite.rs
@@ -634,3 +634,166 @@ pub async fn cleanup_old_summaries(
 
     tx.commit().await
 }
+
+pub async fn enforce_summary_max_rows(pool: &SqlitePool, max_rows: u64) -> Result<(), sqlx::Error> {
+    if max_rows == 0 {
+        return Ok(());
+    }
+    let count_row = sqlx::query("SELECT COUNT(*) FROM conn_summaries").fetch_one(pool).await?;
+    let total: i64 = count_row.get(0);
+
+    if total <= max_rows as i64 {
+        return Ok(());
+    }
+
+    let excess = (total - max_rows as i64) as u64;
+
+    let mut tx = pool.begin().await?;
+    let row = sqlx::query(
+        "SELECT
+            COALESCE(SUM(total_ingress_bytes), 0),
+            COALESCE(SUM(total_egress_bytes), 0),
+            COALESCE(SUM(total_ingress_pkts), 0),
+            COALESCE(SUM(total_egress_pkts), 0),
+            COUNT(*)
+        FROM conn_summaries
+        WHERE (create_time, cpu_id) IN (
+            SELECT create_time, cpu_id FROM conn_summaries ORDER BY last_report_time ASC LIMIT ?1
+        )",
+    )
+    .bind(excess as i64)
+    .fetch_one(tx.as_mut())
+    .await?;
+
+    let removed = ConnectGlobalStats {
+        total_ingress_bytes: row.get::<i64, _>(0).max(0) as u64,
+        total_egress_bytes: row.get::<i64, _>(1).max(0) as u64,
+        total_ingress_pkts: row.get::<i64, _>(2).max(0) as u64,
+        total_egress_pkts: row.get::<i64, _>(3).max(0) as u64,
+        total_connect_count: row.get::<i64, _>(4).max(0) as u64,
+        last_calculate_time: 0,
+    };
+
+    let deleted = sqlx::query(
+        "DELETE FROM conn_summaries
+         WHERE (create_time, cpu_id) IN (
+            SELECT create_time, cpu_id FROM conn_summaries ORDER BY last_report_time ASC LIMIT ?1
+         )",
+    )
+    .bind(excess as i64)
+    .execute(tx.as_mut())
+    .await?
+    .rows_affected();
+
+    if deleted > 0 {
+        let delta = GlobalStatsDelta::from_removed_stats(&removed);
+        apply_global_stats_cache_delta_tx(&mut tx, delta, current_time_ms()).await?;
+    }
+
+    tx.commit().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_pool() -> SqlitePool {
+        let pool =
+            SqlitePoolOptions::new().max_connections(1).connect("sqlite::memory:").await.unwrap();
+        initialize_schema(&pool).await.unwrap();
+        rebuild_global_stats_cache(&pool).await.unwrap();
+        pool
+    }
+
+    async fn insert_test_summary(pool: &SqlitePool, idx: u64, ingress: u64, egress: u64) {
+        use landscape_common::metric::connect::{ConnectMetric, ConnectStatusType};
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let metric = ConnectMetric {
+            key: landscape_common::metric::connect::ConnectKey {
+                create_time: 1000 + idx,
+                cpu_id: 0,
+            },
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+            src_port: 10000,
+            dst_port: 443,
+            l4_proto: 6,
+            l3_proto: 4,
+            flow_id: 0,
+            trace_id: 0,
+            gress: 0,
+            ifindex: 1,
+            report_time: 60_000 * (idx + 1),
+            create_time_ms: 1000 + idx,
+            ingress_bytes: ingress,
+            ingress_packets: 1,
+            egress_bytes: egress,
+            egress_packets: 1,
+            status: ConnectStatusType::Active,
+        };
+
+        let batch = super::super::ingest::PersistenceBatch {
+            summary_metrics: vec![metric],
+            bucket_writes: Vec::new(),
+            iface_bucket_writes: Vec::new(),
+            aggregate_writes: Vec::new(),
+        };
+        apply_persistence_batch(pool, &batch).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn row_cap_eviction_keeps_global_stats_consistent() {
+        let pool = test_pool().await;
+        for i in 0..5u64 {
+            insert_test_summary(&pool, i, 100, 200).await;
+        }
+        let before = query_global_stats(&pool).await.unwrap();
+        assert_eq!(before.total_ingress_bytes, 500);
+        assert_eq!(before.total_egress_bytes, 1000);
+        assert_eq!(before.total_connect_count, 5);
+
+        enforce_summary_max_rows(&pool, 3).await.unwrap();
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM conn_summaries")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 3);
+
+        let after = query_global_stats(&pool).await.unwrap();
+        assert_eq!(after.total_ingress_bytes, 300);
+        assert_eq!(after.total_egress_bytes, 600);
+        assert_eq!(after.total_connect_count, 3);
+    }
+
+    #[tokio::test]
+    async fn row_cap_zero_means_unlimited() {
+        let pool = test_pool().await;
+        for i in 0..5u64 {
+            insert_test_summary(&pool, i, 10, 20).await;
+        }
+        enforce_summary_max_rows(&pool, 0).await.unwrap();
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM conn_summaries")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 5);
+    }
+
+    #[tokio::test]
+    async fn row_cap_no_op_when_under_limit() {
+        let pool = test_pool().await;
+        for i in 0..3u64 {
+            insert_test_summary(&pool, i, 50, 100).await;
+        }
+        let before = query_global_stats(&pool).await.unwrap();
+
+        enforce_summary_max_rows(&pool, 10).await.unwrap();
+
+        let after = query_global_stats(&pool).await.unwrap();
+        assert_eq!(before.total_ingress_bytes, after.total_ingress_bytes);
+        assert_eq!(before.total_connect_count, after.total_connect_count);
+    }
+}

--- a/landscape/src/metric/duckdb/ingest.rs
+++ b/landscape/src/metric/duckdb/ingest.rs
@@ -1,10 +1,11 @@
+use super::connect::schema::AggregateBucketWrite;
 use arc_swap::ArcSwap;
 use landscape_common::config::MetricRuntimeConfig;
 use landscape_common::metric::connect::{
     ConnectKey, ConnectMetric, ConnectMetricPoint, ConnectRealtimeStatus, ConnectStatusType,
     IfaceRealtimeStat, IpAggregatedStats, IpRealtimeStat,
 };
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::IpAddr;
 use std::sync::{Arc, RwLock};
 
@@ -257,6 +258,29 @@ fn scale_u64(value: u64, numerator: u64, denominator: u64) -> u64 {
 }
 
 pub(crate) type IfaceRealtimeCache = Arc<RwLock<HashMap<u32, IfaceRealtimeAcc>>>;
+/// Key of the bounded-cardinality aggregate tier: no connection identity,
+/// no dst_ip, no src_port. One device hitting 1000 hosts on 443 is one key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct AggregateBucketKey {
+    pub(crate) bucket_start: u64,
+    pub(crate) src_ip: String,
+    pub(crate) l4_proto: u8,
+    pub(crate) dst_port: u16,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct AggregateBucketAcc {
+    pub(crate) ingress_bytes: u64,
+    pub(crate) ingress_packets: u64,
+    pub(crate) egress_bytes: u64,
+    pub(crate) egress_packets: u64,
+    /// Connections already counted in this bucket. A connection contributes many
+    /// deltas, so conn_count must only rise on its first touch of the bucket.
+    pub(crate) seen_conns: HashSet<ConnectKey>,
+}
+
+pub(crate) type AggregateBucketCache = Arc<RwLock<HashMap<AggregateBucketKey, AggregateBucketAcc>>>;
+
 pub(crate) type IfaceBucketCache = Arc<RwLock<HashMap<IfaceBucketKey, IfaceBucketAcc>>>;
 pub(crate) type IfaceRealtimeSnapshot = Arc<ArcSwap<Vec<IfaceRealtimeStat>>>;
 pub(crate) type ConnectRealtimeSnapshot = Arc<ArcSwap<Vec<ConnectRealtimeStatus>>>;
@@ -302,6 +326,7 @@ pub(crate) struct PersistenceBatch {
     pub summary_metrics: Vec<ConnectMetric>,
     pub bucket_writes: Vec<BucketWrite>,
     pub iface_bucket_writes: Vec<IfaceBucketWrite>,
+    pub aggregate_writes: Vec<AggregateBucketWrite>,
 }
 
 impl PersistenceBatch {
@@ -309,16 +334,21 @@ impl PersistenceBatch {
         self.summary_metrics.is_empty()
             && self.bucket_writes.is_empty()
             && self.iface_bucket_writes.is_empty()
+            && self.aggregate_writes.is_empty()
     }
 
     pub(crate) fn op_count(&self) -> usize {
-        self.summary_metrics.len() + self.bucket_writes.len() + self.iface_bucket_writes.len()
+        self.summary_metrics.len()
+            + self.bucket_writes.len()
+            + self.iface_bucket_writes.len()
+            + self.aggregate_writes.len()
     }
 
     pub(crate) fn extend(&mut self, other: Self) {
         self.summary_metrics.extend(other.summary_metrics);
         self.bucket_writes.extend(other.bucket_writes);
         self.iface_bucket_writes.extend(other.iface_bucket_writes);
+        self.aggregate_writes.extend(other.aggregate_writes);
     }
 
     fn push_summary(&mut self, metric: ConnectMetric) {
@@ -331,6 +361,10 @@ impl PersistenceBatch {
 
     pub(crate) fn extend_iface_buckets(&mut self, writes: Vec<IfaceBucketWrite>) {
         self.iface_bucket_writes.extend(writes);
+    }
+
+    pub(crate) fn extend_aggregates(&mut self, writes: Vec<AggregateBucketWrite>) {
+        self.aggregate_writes.extend(writes);
     }
 }
 
@@ -643,6 +677,7 @@ pub(crate) fn process_connect_metric(
     flow_cache: &FlowCache,
     iface_realtime: &IfaceRealtimeCache,
     iface_buckets: &IfaceBucketCache,
+    aggregate_buckets: &AggregateBucketCache,
     metric: ConnectMetric,
     second_window_ms: u64,
     second_ring_cap: usize,
@@ -661,6 +696,13 @@ pub(crate) fn process_connect_metric(
             }
 
             record_metric_iface_delta(iface_buckets, Some(&state.last_metric), &metric);
+            record_aggregate_delta(
+                aggregate_buckets,
+                &metric,
+                state.last_metric.report_time,
+                metric.report_time,
+                MetricDelta::from_metrics(&state.last_metric, &metric),
+            );
             remove_state_iface_realtime(iface_realtime, state);
 
             let previous_minute_bucket = minute_slot(state.last_metric.report_time);
@@ -691,6 +733,16 @@ pub(crate) fn process_connect_metric(
         }
         std::collections::hash_map::Entry::Vacant(entry) => {
             record_metric_iface_delta(iface_buckets, None, &metric);
+            // The iface gauge deliberately drops a first report (it measures rate),
+            // but this tier is accounting: a connection that reports once and ends
+            // would otherwise never appear, and never raise conn_count.
+            record_aggregate_delta(
+                aggregate_buckets,
+                &metric,
+                metric.create_time_ms,
+                metric.report_time,
+                MetricDelta::from_initial(&metric),
+            );
             let should_finalize = metric.status == ConnectStatusType::Disabled;
             let mut state = FlowState::new(metric, second_window_ms, second_ring_cap);
             if should_finalize {
@@ -866,5 +918,154 @@ mod bucket_prune_tests {
     #[test]
     fn missing_create_time_is_treated_as_crossing() {
         assert!(crosses_bucket(0, 10 * MS_PER_HOUR, MS_PER_HOUR));
+    }
+}
+
+pub(crate) const AGGREGATE_BUCKET_MS: u64 = MS_PER_HOUR;
+
+/// Fold one reporting delta into the aggregate tier, splitting across bucket
+/// boundaries in proportion to elapsed time.
+///
+/// Mirrors record_iface_delta: the final bucket absorbs the rounding remainder so
+/// the per-bucket sums equal the delta exactly. Writing only at finalize would
+/// dump a long connection s whole lifetime into the hour it happened to end in.
+fn record_aggregate_delta(
+    cache: &AggregateBucketCache,
+    metric: &ConnectMetric,
+    start_time: u64,
+    end_time: u64,
+    delta: MetricDelta,
+) {
+    if delta.is_zero() {
+        return;
+    }
+    let src_ip = clean_ip_string(&metric.src_ip);
+    let mut cache = cache.write().expect("metric aggregate bucket cache poisoned");
+    let mut apply = |bucket_start: u64, d: MetricDelta| {
+        let key = AggregateBucketKey {
+            bucket_start,
+            src_ip: src_ip.clone(),
+            l4_proto: metric.l4_proto,
+            dst_port: metric.dst_port,
+        };
+        let acc = cache.entry(key).or_default();
+        acc.ingress_bytes = acc.ingress_bytes.saturating_add(d.ingress_bytes);
+        acc.ingress_packets = acc.ingress_packets.saturating_add(d.ingress_packets);
+        acc.egress_bytes = acc.egress_bytes.saturating_add(d.egress_bytes);
+        acc.egress_packets = acc.egress_packets.saturating_add(d.egress_packets);
+        acc.seen_conns.insert(metric.key.clone());
+    };
+
+    if end_time <= start_time {
+        apply(bucket_start(end_time, AGGREGATE_BUCKET_MS), delta);
+        return;
+    }
+
+    let total_duration = end_time - start_time;
+    let mut cursor = start_time;
+    let mut assigned = MetricDelta::default();
+    while cursor < end_time {
+        let bucket = bucket_start(cursor, AGGREGATE_BUCKET_MS);
+        let bucket_end = bucket.saturating_add(AGGREGATE_BUCKET_MS).min(end_time);
+        let mut segment_delta = delta.scale(bucket_end.saturating_sub(cursor), total_duration);
+        if bucket_end >= end_time {
+            segment_delta = delta.saturating_sub(assigned);
+        } else {
+            assigned = assigned.saturating_add(segment_delta);
+        }
+        apply(bucket, segment_delta);
+        cursor = bucket_end;
+    }
+}
+
+pub(crate) fn drain_aggregate_buckets(cache: &AggregateBucketCache) -> Vec<AggregateBucketWrite> {
+    let mut buckets = cache.write().expect("metric aggregate bucket cache poisoned");
+    buckets
+        .drain()
+        .map(|(key, acc)| AggregateBucketWrite {
+            report_time: key.bucket_start,
+            src_ip: key.src_ip,
+            l4_proto: key.l4_proto,
+            dst_port: key.dst_port,
+            ingress_bytes: acc.ingress_bytes,
+            ingress_packets: acc.ingress_packets,
+            egress_bytes: acc.egress_bytes,
+            egress_packets: acc.egress_packets,
+            conn_count: acc.seen_conns.len() as u64,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod aggregate_delta_tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn test_metric(create_time_ms: u64, report_time: u64) -> ConnectMetric {
+        ConnectMetric {
+            key: ConnectKey { create_time: create_time_ms * 1_000_000, cpu_id: 0 },
+            src_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 100, 20)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
+            src_port: 51234,
+            dst_port: 443,
+            l4_proto: 6,
+            l3_proto: 4,
+            flow_id: 1,
+            trace_id: 0,
+            gress: 0,
+            ifindex: 2,
+            report_time,
+            create_time_ms,
+            ingress_bytes: 0,
+            ingress_packets: 0,
+            egress_bytes: 0,
+            egress_packets: 0,
+            status: ConnectStatusType::Active,
+        }
+    }
+
+    fn new_cache() -> AggregateBucketCache {
+        Arc::new(RwLock::new(HashMap::new()))
+    }
+
+    #[test]
+    fn cross_bucket_split_conserves_total() {
+        let cache = new_cache();
+        let start = 10 * MS_PER_HOUR + 1_800_000;
+        let end = 12 * MS_PER_HOUR + 1_800_000;
+        let metric = test_metric(start, end);
+        let delta = MetricDelta {
+            ingress_bytes: 1000,
+            ingress_packets: 10,
+            egress_bytes: 2000,
+            egress_packets: 20,
+        };
+        record_aggregate_delta(&cache, &metric, start, end, delta);
+        let writes = drain_aggregate_buckets(&cache);
+        assert_eq!(writes.len(), 3, "should land in 3 hour buckets");
+        let total_in: u64 = writes.iter().map(|w| w.ingress_bytes).sum();
+        let total_out: u64 = writes.iter().map(|w| w.egress_bytes).sum();
+        assert_eq!(total_in, 1000, "per-bucket sums must equal the delta exactly");
+        assert_eq!(total_out, 2000);
+    }
+
+    #[test]
+    fn conn_count_counts_each_connection_once_per_bucket() {
+        let cache = new_cache();
+        let base = 10 * MS_PER_HOUR;
+        let metric = test_metric(base, base + 1000);
+        let d = MetricDelta {
+            ingress_bytes: 1,
+            ingress_packets: 1,
+            egress_bytes: 1,
+            egress_packets: 1,
+        };
+        for _ in 0..3 {
+            record_aggregate_delta(&cache, &metric, base, base + 1000, d);
+        }
+        let writes = drain_aggregate_buckets(&cache);
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].conn_count, 1, "same connection must count once");
+        assert_eq!(writes[0].ingress_bytes, 3, "but its bytes still accumulate");
     }
 }

--- a/landscape/src/metric/duckdb/ingest.rs
+++ b/landscape/src/metric/duckdb/ingest.rs
@@ -21,6 +21,16 @@ pub(crate) fn bucket_start(report_time: u64, bucket_ms: u64) -> u64 {
     report_time / bucket_ms * bucket_ms
 }
 
+/// Whether a connection actually spans two or more buckets at this resolution.
+///
+/// A connection living inside a single bucket produces a row that is a copy of its
+/// summary rather than an aggregate, and the chart never asks for that resolution
+/// (it picks one from connection age). Returns true when create_time_ms is 0
+/// (missing) so we over-write rather than lose a row.
+pub(crate) fn crosses_bucket(create_time_ms: u64, report_time: u64, bucket_ms: u64) -> bool {
+    bucket_start(create_time_ms, bucket_ms) != bucket_start(report_time, bucket_ms)
+}
+
 pub(crate) fn minute_slot(report_time: u64) -> u64 {
     bucket_start(report_time, MS_PER_MINUTE)
 }
@@ -530,16 +540,20 @@ fn finalize_state_batch(
     }
 
     batch.push_bucket(BucketKind::Minute, metric.clone(), minute_slot(metric.report_time));
-    batch.push_bucket(
-        BucketKind::Hour,
-        metric.clone(),
-        bucket_start(metric.report_time, MS_PER_HOUR),
-    );
-    batch.push_bucket(
-        BucketKind::Day,
-        metric.clone(),
-        bucket_start(metric.report_time, MS_PER_DAY),
-    );
+    if crosses_bucket(metric.create_time_ms, metric.report_time, MS_PER_HOUR) {
+        batch.push_bucket(
+            BucketKind::Hour,
+            metric.clone(),
+            bucket_start(metric.report_time, MS_PER_HOUR),
+        );
+    }
+    if crosses_bucket(metric.create_time_ms, metric.report_time, MS_PER_DAY) {
+        batch.push_bucket(
+            BucketKind::Day,
+            metric.clone(),
+            bucket_start(metric.report_time, MS_PER_DAY),
+        );
+    }
     batch.push_summary(metric);
     state.finalized = true;
 }
@@ -829,4 +843,28 @@ pub(crate) fn second_points_by_key(
 ) -> Vec<ConnectMetricPoint> {
     let cache = flow_cache.read().expect("metric flow cache poisoned");
     cache.get(key).map(|state| state.second_points_since(cutoff)).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod bucket_prune_tests {
+    use super::*;
+
+    #[test]
+    fn same_hour_does_not_cross() {
+        let create = 10 * MS_PER_HOUR + 5_000;
+        let report = 10 * MS_PER_HOUR + 10_000;
+        assert!(!crosses_bucket(create, report, MS_PER_HOUR));
+    }
+
+    #[test]
+    fn spanning_hour_boundary_crosses() {
+        let create = 10 * MS_PER_HOUR + 3_595_000;
+        let report = 11 * MS_PER_HOUR + 5_000;
+        assert!(crosses_bucket(create, report, MS_PER_HOUR));
+    }
+
+    #[test]
+    fn missing_create_time_is_treated_as_crossing() {
+        assert!(crosses_bucket(0, 10 * MS_PER_HOUR, MS_PER_HOUR));
+    }
 }

--- a/landscape/src/metric/duckdb/store.rs
+++ b/landscape/src/metric/duckdb/store.rs
@@ -3,8 +3,9 @@ use landscape_common::concurrency::{spawn_named_thread, task_label, thread_name}
 use landscape_common::config::MetricRuntimeConfig;
 use landscape_common::event::{ConnectMessage, DnsMetricMessage};
 use landscape_common::metric::connect::{
-    ConnectHistoryQueryParams, ConnectHistoryStatus, ConnectKey, ConnectMetricPoint,
-    ConnectRealtimeStatus, IfaceRealtimeStat, IpHistoryStat, IpRealtimeStat, MetricResolution,
+    ConnectAggregatePoint, ConnectAggregateQueryParams, ConnectHistoryQueryParams,
+    ConnectHistoryStatus, ConnectKey, ConnectMetricPoint, ConnectRealtimeStatus, IfaceRealtimeStat,
+    IpHistoryStat, IpRealtimeStat, MetricResolution,
 };
 use landscape_common::metric::dns::{
     DnsHistoryQueryParams, DnsHistoryResponse, DnsLightweightSummaryResponse, DnsMetric,
@@ -389,9 +390,13 @@ async fn run_hot_thread(
                 publish_connect_realtime_snapshot(&flow_cache, &connect_snapshot, now_ms);
                 publish_iface_realtime_snapshot(&flow_cache, &iface_snapshot, now_ms);
 
-                let summary_cutoff = now_ms.saturating_sub(metric_config.connect_1d_retention_days * MS_PER_DAY);
+                let summary_cutoff = now_ms.saturating_sub(metric_config.connect_summary_retention_days * MS_PER_DAY);
                 if let Err(error) = hot_sqlite::cleanup_old_summaries(&hot_pool, summary_cutoff).await {
                     tracing::error!("failed to cleanup hot conn_summaries: {}", error);
+                }
+
+                if let Err(error) = hot_sqlite::enforce_summary_max_rows(&hot_pool, metric_config.connect_summary_max_rows).await {
+                    tracing::error!("failed to enforce conn_summaries max rows: {}", error);
                 }
 
                 tracing::info!(
@@ -930,6 +935,19 @@ impl DuckMetricStore {
         })
         .await
     }
+
+    pub async fn query_connection_aggregates(
+        &self,
+        params: ConnectAggregateQueryParams,
+    ) -> Vec<ConnectAggregatePoint> {
+        self.run_cold_query_default(task_label::op::METRIC_CONNECT_AGGREGATES, move |pool| {
+            let Ok(conn) = pool.get() else {
+                return Vec::new();
+            };
+            connect_query::query_connection_aggregates(&conn, params)
+        })
+        .await
+    }
 }
 
 #[cfg(test)]
@@ -957,6 +975,8 @@ mod tests {
             connect_1h_retention_days: 30,
             connect_1d_retention_days: 90,
             connect_aggregate_retention_days: 180,
+            connect_summary_retention_days: 90,
+            connect_summary_max_rows: 0,
             dns_retention_days: 7,
             write_batch_size: 16,
             write_flush_interval_secs: 1,

--- a/landscape/src/metric/duckdb/store.rs
+++ b/landscape/src/metric/duckdb/store.rs
@@ -18,17 +18,18 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch};
 
+use super::connect::schema::AggregateBucketWrite;
 use super::connect::{cleanup, query as connect_query, schema as connect_schema};
 use super::dns::{history as dns_history, schema as dns_schema, summary as dns_summary};
 use super::hot_sqlite;
 use super::ingest::{
     cleanup_flow_cache, collect_connect_realtime_snapshot, collect_iface_realtime_snapshot,
-    collect_realtime_ip_stats, drain_iface_buckets, finalize_all_flows,
+    collect_realtime_ip_stats, drain_aggregate_buckets, drain_iface_buckets, finalize_all_flows,
     new_connect_realtime_snapshot, new_iface_realtime_snapshot, process_connect_metric,
     publish_connect_realtime_snapshot, publish_iface_realtime_snapshot, second_points_by_key,
-    second_ring_capacity, second_window_ms, BucketWrite, ConnectRealtimeSnapshot, FlowCache,
-    IfaceBucketCache, IfaceBucketWrite, IfaceRealtimeCache, IfaceRealtimeSnapshot,
-    PersistenceBatch, CHANNEL_CAPACITY, MS_PER_DAY,
+    second_ring_capacity, second_window_ms, AggregateBucketCache, BucketWrite,
+    ConnectRealtimeSnapshot, FlowCache, IfaceBucketCache, IfaceBucketWrite, IfaceRealtimeCache,
+    IfaceRealtimeSnapshot, PersistenceBatch, CHANNEL_CAPACITY, MS_PER_DAY,
 };
 
 #[derive(Clone)]
@@ -52,7 +53,7 @@ const COLD_RETRY_DELAY_SECS: u64 = 5;
 
 #[derive(Debug)]
 enum ColdEvent {
-    Buckets(Vec<BucketWrite>, Vec<IfaceBucketWrite>),
+    Buckets(Vec<BucketWrite>, Vec<IfaceBucketWrite>, Vec<AggregateBucketWrite>),
     Dns(DnsMetric),
 }
 
@@ -288,8 +289,15 @@ async fn flush_pending_hot_batch(
     let batch = std::mem::take(pending_batch);
     let bucket_writes = batch.bucket_writes.clone();
     let iface_bucket_writes = batch.iface_bucket_writes.clone();
+    let aggregate_writes = batch.aggregate_writes.clone();
     apply_hot_batch(hot_pool, &batch).await;
-    try_enqueue_cold_buckets(cold_tx, cold_pool_cell, bucket_writes, iface_bucket_writes);
+    try_enqueue_cold_buckets(
+        cold_tx,
+        cold_pool_cell,
+        bucket_writes,
+        iface_bucket_writes,
+        aggregate_writes,
+    );
 }
 
 fn cold_store_ready(
@@ -303,14 +311,17 @@ fn try_enqueue_cold_buckets(
     cold_pool_cell: &Arc<RwLock<Option<r2d2::Pool<DuckdbConnectionManager>>>>,
     bucket_writes: Vec<BucketWrite>,
     iface_bucket_writes: Vec<IfaceBucketWrite>,
+    aggregate_writes: Vec<AggregateBucketWrite>,
 ) {
-    if (bucket_writes.is_empty() && iface_bucket_writes.is_empty())
+    if (bucket_writes.is_empty() && iface_bucket_writes.is_empty() && aggregate_writes.is_empty())
         || !cold_store_ready(cold_pool_cell)
     {
         return;
     }
 
-    if let Err(error) = cold_tx.try_send(ColdEvent::Buckets(bucket_writes, iface_bucket_writes)) {
+    if let Err(error) =
+        cold_tx.try_send(ColdEvent::Buckets(bucket_writes, iface_bucket_writes, aggregate_writes))
+    {
         tracing::debug!("dropping cold metric bucket batch: {:?}", error);
     }
 }
@@ -339,6 +350,7 @@ async fn run_hot_thread(
     flow_cache: FlowCache,
     iface_realtime: IfaceRealtimeCache,
     iface_buckets: IfaceBucketCache,
+    aggregate_buckets: AggregateBucketCache,
     connect_snapshot: ConnectRealtimeSnapshot,
     iface_snapshot: IfaceRealtimeSnapshot,
     mut shutdown_rx: watch::Receiver<bool>,
@@ -365,12 +377,14 @@ async fn run_hot_thread(
         tokio::select! {
             _ = cleanup_interval.tick() => {
                 pending_batch.extend_iface_buckets(drain_iface_buckets(&iface_buckets, &iface_realtime));
+                pending_batch.extend_aggregates(drain_aggregate_buckets(&aggregate_buckets));
                 flush_pending_hot_batch(&hot_pool, &cold_tx, &cold_pool_cell, &mut pending_batch).await;
 
                 let now_ms = get_current_time_ms().unwrap_or_default();
                 let (flow_stats, batch) = cleanup_flow_cache(&flow_cache, &iface_realtime, now_ms, second_window);
                 pending_batch.extend(batch);
                 pending_batch.extend_iface_buckets(drain_iface_buckets(&iface_buckets, &iface_realtime));
+                pending_batch.extend_aggregates(drain_aggregate_buckets(&aggregate_buckets));
                 flush_pending_hot_batch(&hot_pool, &cold_tx, &cold_pool_cell, &mut pending_batch).await;
                 publish_connect_realtime_snapshot(&flow_cache, &connect_snapshot, now_ms);
                 publish_iface_realtime_snapshot(&flow_cache, &iface_snapshot, now_ms);
@@ -390,6 +404,7 @@ async fn run_hot_thread(
             }
             _ = flush_interval.tick() => {
                 pending_batch.extend_iface_buckets(drain_iface_buckets(&iface_buckets, &iface_realtime));
+                pending_batch.extend_aggregates(drain_aggregate_buckets(&aggregate_buckets));
                 flush_pending_hot_batch(&hot_pool, &cold_tx, &cold_pool_cell, &mut pending_batch).await;
             }
             _ = snapshot_interval.tick() => {
@@ -409,6 +424,7 @@ async fn run_hot_thread(
                             &flow_cache,
                             &iface_realtime,
                             &iface_buckets,
+                            &aggregate_buckets,
                             metric,
                             second_window,
                             second_ring_cap,
@@ -416,6 +432,7 @@ async fn run_hot_thread(
                         pending_batch.extend(batch);
                         if pending_batch.op_count() >= write_batch_size {
                             pending_batch.extend_iface_buckets(drain_iface_buckets(&iface_buckets, &iface_realtime));
+                pending_batch.extend_aggregates(drain_aggregate_buckets(&aggregate_buckets));
                             flush_pending_hot_batch(&hot_pool, &cold_tx, &cold_pool_cell, &mut pending_batch).await;
                         }
                     }
@@ -438,11 +455,13 @@ async fn run_hot_thread(
     }
 
     pending_batch.extend_iface_buckets(drain_iface_buckets(&iface_buckets, &iface_realtime));
+    pending_batch.extend_aggregates(drain_aggregate_buckets(&aggregate_buckets));
     flush_pending_hot_batch(&hot_pool, &cold_tx, &cold_pool_cell, &mut pending_batch).await;
 
     let final_batch = finalize_all_flows(&flow_cache, &iface_realtime);
     pending_batch.extend(final_batch);
     pending_batch.extend_iface_buckets(drain_iface_buckets(&iface_buckets, &iface_realtime));
+    pending_batch.extend_aggregates(drain_aggregate_buckets(&aggregate_buckets));
     flush_pending_hot_batch(&hot_pool, &cold_tx, &cold_pool_cell, &mut pending_batch).await;
     let now_ms = get_current_time_ms().unwrap_or_default();
     publish_connect_realtime_snapshot(&flow_cache, &connect_snapshot, now_ms);
@@ -454,8 +473,9 @@ fn persist_cold_bucket_writes(
     cold_pool: &r2d2::Pool<DuckdbConnectionManager>,
     bucket_writes: &[BucketWrite],
     iface_bucket_writes: &[IfaceBucketWrite],
+    aggregate_writes: &[AggregateBucketWrite],
 ) -> StoreInitResult<()> {
-    if bucket_writes.is_empty() && iface_bucket_writes.is_empty() {
+    if bucket_writes.is_empty() && iface_bucket_writes.is_empty() && aggregate_writes.is_empty() {
         return Ok(());
     }
 
@@ -498,6 +518,11 @@ fn persist_cold_bucket_writes(
         .map_err(|error| format!("failed to write cold iface bucket row: {}", error))?;
     }
 
+    for aggregate in aggregate_writes {
+        connect_schema::upsert_aggregate_bucket_values(&conn, aggregate)
+            .map_err(|error| format!("failed to write cold aggregate row: {}", error))?;
+    }
+
     Ok(())
 }
 
@@ -533,8 +558,13 @@ fn persist_cold_event(
     event: ColdEvent,
 ) -> StoreInitResult<()> {
     match event {
-        ColdEvent::Buckets(bucket_writes, iface_bucket_writes) => {
-            persist_cold_bucket_writes(cold_pool, &bucket_writes, &iface_bucket_writes)
+        ColdEvent::Buckets(bucket_writes, iface_bucket_writes, aggregate_writes) => {
+            persist_cold_bucket_writes(
+                cold_pool,
+                &bucket_writes,
+                &iface_bucket_writes,
+                &aggregate_writes,
+            )
         }
         ColdEvent::Dns(metric) => persist_cold_dns_metric(cold_pool, &metric),
     }
@@ -551,6 +581,8 @@ fn cleanup_cold_store(
     let cutoff_1m = now_ms.saturating_sub(metric_config.connect_1m_retention_days * MS_PER_DAY);
     let cutoff_1h = now_ms.saturating_sub(metric_config.connect_1h_retention_days * MS_PER_DAY);
     let cutoff_1d = now_ms.saturating_sub(metric_config.connect_1d_retention_days * MS_PER_DAY);
+    let cutoff_aggregate =
+        now_ms.saturating_sub(metric_config.connect_aggregate_retention_days * MS_PER_DAY);
     let cutoff_dns = now_ms.saturating_sub(metric_config.dns_retention_days * MS_PER_DAY);
 
     dns_schema::cleanup_old_dns_metrics(&conn, cutoff_dns);
@@ -559,17 +591,19 @@ fn cleanup_cold_store(
         cutoff_1m,
         cutoff_1h,
         cutoff_1d,
+        cutoff_aggregate,
         metric_config.cleanup_time_budget_ms,
         metric_config.cleanup_slice_window_secs,
     );
     tracing::info!(
-        "phase=cold_duckdb.cleanup elapsed_ms={} budget_hit={} deleted_iface_5s={} deleted_1m={} deleted_1h={} deleted_1d={} deleted_dns_before={}",
+        "phase=cold_duckdb.cleanup elapsed_ms={} budget_hit={} deleted_iface_5s={} deleted_1m={} deleted_1h={} deleted_1d={} deleted_aggregate={} deleted_dns_before={}",
         stats.elapsed_ms,
         stats.budget_hit,
         stats.deleted_iface_5s,
         stats.deleted_1m,
         stats.deleted_1h,
         stats.deleted_1d,
+        stats.deleted_aggregate,
         cutoff_dns,
     );
     if let Err(error) = conn.execute("CHECKPOINT", []) {
@@ -696,6 +730,7 @@ impl DuckMetricStore {
         let flow_cache: FlowCache = Arc::new(RwLock::new(HashMap::new()));
         let iface_realtime: IfaceRealtimeCache = Arc::new(RwLock::new(HashMap::new()));
         let iface_buckets: IfaceBucketCache = Arc::new(RwLock::new(HashMap::new()));
+        let aggregate_buckets: AggregateBucketCache = Arc::new(RwLock::new(HashMap::new()));
         let connect_snapshot = new_connect_realtime_snapshot();
         let iface_snapshot = new_iface_realtime_snapshot();
         let cold_pool = Arc::new(RwLock::new(None));
@@ -704,6 +739,7 @@ impl DuckMetricStore {
         let hot_thread_cache = flow_cache.clone();
         let hot_thread_iface_realtime = iface_realtime.clone();
         let hot_thread_iface_buckets = iface_buckets.clone();
+        let hot_thread_aggregate_buckets = aggregate_buckets.clone();
         let hot_thread_connect_snapshot = connect_snapshot.clone();
         let hot_thread_iface_snapshot = iface_snapshot.clone();
         let hot_thread_cold_pool = cold_pool.clone();
@@ -723,6 +759,7 @@ impl DuckMetricStore {
                 hot_thread_cache,
                 hot_thread_iface_realtime,
                 hot_thread_iface_buckets,
+                hot_thread_aggregate_buckets,
                 hot_thread_connect_snapshot,
                 hot_thread_iface_snapshot,
                 hot_thread_shutdown,
@@ -919,6 +956,7 @@ mod tests {
             connect_1m_retention_days: 7,
             connect_1h_retention_days: 30,
             connect_1d_retention_days: 90,
+            connect_aggregate_retention_days: 180,
             dns_retention_days: 7,
             write_batch_size: 16,
             write_flush_interval_secs: 1,
@@ -1043,6 +1081,7 @@ mod tests {
             summary_metrics: vec![metric_a_initial, metric_a_latest, metric_b],
             bucket_writes: Vec::new(),
             iface_bucket_writes: Vec::new(),
+            aggregate_writes: Vec::new(),
         };
         hot_sqlite::apply_persistence_batch(&hot_pool, &batch).await.unwrap();
         sqlx::query(

--- a/landscape/src/metric/mod.rs
+++ b/landscape/src/metric/mod.rs
@@ -7,9 +7,9 @@ use landscape_common::{
     error::LdResult,
     event::{ConnectMessage, DnsMetricMessage},
     metric::connect::{
-        ConnectGlobalStats, ConnectHistoryQueryParams, ConnectHistoryStatus, ConnectKey,
-        ConnectMetricPoint, ConnectRealtimeStatus, IfaceRealtimeStat, IpHistoryStat,
-        IpRealtimeStat, MetricResolution,
+        ConnectAggregatePoint, ConnectAggregateQueryParams, ConnectGlobalStats,
+        ConnectHistoryQueryParams, ConnectHistoryStatus, ConnectKey, ConnectMetricPoint,
+        ConnectRealtimeStatus, IfaceRealtimeStat, IpHistoryStat, IpRealtimeStat, MetricResolution,
     },
     metric::dns::{
         DnsHistoryQueryParams, DnsHistoryResponse, DnsLightweightSummaryResponse,
@@ -214,6 +214,18 @@ impl MetricBackend {
             Self::Duckdb(store) => store.get_dns_lightweight_summary(params).await,
         }
     }
+
+    async fn query_connection_aggregates(
+        &self,
+        #[allow(unused_variables)] params: ConnectAggregateQueryParams,
+    ) -> Vec<ConnectAggregatePoint> {
+        match self {
+            Self::Off => Vec::new(),
+            Self::Memory(_) => Vec::new(),
+            #[cfg(feature = "metric-duckdb")]
+            Self::Duckdb(store) => store.query_connection_aggregates(params).await,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -392,6 +404,13 @@ impl MetricService {
         params: DnsSummaryQueryParams,
     ) -> DnsLightweightSummaryResponse {
         self.current_backend().get_dns_lightweight_summary(params).await
+    }
+
+    pub async fn query_connection_aggregates(
+        &self,
+        params: ConnectAggregateQueryParams,
+    ) -> Vec<ConnectAggregatePoint> {
+        self.current_backend().query_connection_aggregates(params).await
     }
 }
 


### PR DESCRIPTION
## 概要

本 PR 添加有界基数流量聚合管道及其查询端点，并为连接摘要表引入独立的保留期和条数控制。

### 提交记录

1. `perf(metric): only write coarse buckets for connections spanning them` — 跳过未跨越分钟/小时/天边界的连接的粗粒度 bucket 写入
2. `feat(metric): add bounded-cardinality traffic aggregate tier` — 新增 `conn_aggregates_1h` 表，按 (bucket, src_ip, l4_proto, dst_port) 索引，累加式 upsert
3. `feat(metric): add aggregate query endpoint and summary retention controls` — 聚合查询端点 + 保留期/条数硬顶配置

### 新端点

`GET /metrics/connections/aggregates`

| 参数 | 类型 | 默认值 | 说明 |
|------|------|--------|------|
| group_by | srcip \| dstport | srcip | 分组维度 |
| start_time | u64 | - | 起始时间（毫秒，含） |
| end_time | u64 | - | 结束时间（毫秒，不含） |
| src_ip | string | - | 按源 IP 过滤 |
| dst_port | u16 | - | 按目标端口过滤 |
| l4_proto | u8 | - | 按四层协议过滤 |
| limit | usize | 100（最大 1000） | 返回条数上限 |

### 新配置字段

- `connect_summary_retention_days` — conn_summaries 独立保留天数（默认继承 `connect_1d_retention_days`）
- `connect_summary_max_rows` — 条数硬顶，淘汰最旧行时通过 `apply_global_stats_cache_delta_tx` 保持全局统计缓存一致（0 = 禁用）

### 测试

- 291 项测试通过（4 项已知环境依赖失败无变化）
- 新增单元测试覆盖聚合查询的分组、过滤、limit 逻辑
- `gen_ts_bindings.sh` 和前端 build 均通过