### PR TITLE
fix(nat): flush stale egress NAT mappings on WAN IP change

### DIFF
--- a/landscape-ebpf/src/lib.rs
+++ b/landscape-ebpf/src/lib.rs
@@ -32,6 +32,8 @@ static MAP_PATHS: Lazy<LandscapeMapPath> = Lazy::new(|| {
         wan_ip: PathBuf::from(format!("{}/wan_ip_binding", ebpf_map_path)),
         nat6_static_map: PathBuf::from(format!("{}/nat6_static_map", ebpf_map_path)),
         nat4_static_map: PathBuf::from(format!("{}/nat4_static_map", ebpf_map_path)),
+        nat4_egress_dyn_map: PathBuf::from(format!("{}/nat4_egress_dyn_map", ebpf_map_path)),
+        nat4_ingress_dyn_map: PathBuf::from(format!("{}/nat4_ingress_dyn_map", ebpf_map_path)),
 
         firewall_ipv4_block: PathBuf::from(format!("{}/firewall_block_ip4_map", ebpf_map_path)),
         firewall_ipv6_block: PathBuf::from(format!("{}/firewall_block_ip6_map", ebpf_map_path)),
@@ -82,6 +84,8 @@ pub(crate) struct LandscapeMapPath {
     // NAT
     pub nat6_static_map: PathBuf,
     pub nat4_static_map: PathBuf,
+    pub nat4_egress_dyn_map: PathBuf,
+    pub nat4_ingress_dyn_map: PathBuf,
 
     // 防火墙黑名单
     pub firewall_ipv4_block: PathBuf,

--- a/landscape-ebpf/src/map_setting/mod.rs
+++ b/landscape-ebpf/src/map_setting/mod.rs
@@ -310,7 +310,98 @@ pub fn add_ipv4_wan_ip(
     mac: Option<MacAddr>,
 ) {
     let wan_ip_binding = libbpf_rs::MapHandle::from_pinned_path(&MAP_PATHS.wan_ip).unwrap();
+
+    // Read the previous WAN IP before overwriting. If it differs from the new
+    // one, flush stale dynamic NAT egress mappings that still reference it.
+    let mut key = wan_ip_info_key::default();
+    key.ifindex = ifindex;
+    key.l3_protocol = LANDSCAPE_IPV4_TYPE;
+    let key_bytes = unsafe { plain::as_bytes(&key) };
+    if let Ok(Some(old_value_bytes)) = wan_ip_binding.lookup(key_bytes, MapFlags::ANY) {
+        if old_value_bytes.len() >= std::mem::size_of::<wan_ip_info_value>() {
+            let old_value: &wan_ip_info_value =
+                unsafe { &*(old_value_bytes.as_ptr() as *const wan_ip_info_value) };
+            let old_ip = Ipv4Addr::from(u32::from_be(unsafe { old_value.addr.ip }));
+            if old_ip != addr {
+                flush_stale_nat4_egress_mappings(old_ip);
+            }
+        }
+    }
+
     add_wan_ip(&wan_ip_binding, ifindex, IpAddr::V4(addr), gateway.map(IpAddr::V4), mask, mac);
+}
+
+/// Remove dynamic NAT egress mappings whose mapped source address equals
+/// `old_wan_ip`. Called when the WAN IP changes (e.g. PPPoE redial) so that
+/// long-lived UDP flows (WireGuard, Tailscale) are forced to recreate mappings
+/// with the new address instead of silently sending packets from the stale one.
+fn flush_stale_nat4_egress_mappings(old_wan_ip: Ipv4Addr) {
+    let egress_map = match libbpf_rs::MapHandle::from_pinned_path(&MAP_PATHS.nat4_egress_dyn_map) {
+        Ok(map) => map,
+        Err(e) => {
+            tracing::warn!("cannot open nat4_egress_dyn_map for flush: {e}");
+            return;
+        }
+    };
+    let ingress_map = match libbpf_rs::MapHandle::from_pinned_path(&MAP_PATHS.nat4_ingress_dyn_map)
+    {
+        Ok(map) => map,
+        Err(e) => {
+            tracing::warn!("cannot open nat4_ingress_dyn_map for flush: {e}");
+            return;
+        }
+    };
+
+    flush_nat4_dyn_maps_by_old_ip(&egress_map, &ingress_map, old_wan_ip);
+}
+
+/// Core flush logic: iterate `egress_map`, delete entries whose mapped source
+/// address (value bytes 0..4) equals `old_wan_ip`, and delete the corresponding
+/// entries from `ingress_map`.
+pub(crate) fn flush_nat4_dyn_maps_by_old_ip(
+    egress_map: &impl MapCore,
+    ingress_map: &impl MapCore,
+    old_wan_ip: Ipv4Addr,
+) -> usize {
+    let old_ip_bytes = old_wan_ip.octets();
+
+    // Collect keys to delete (cannot delete while iterating).
+    let mut stale_egress_keys: Vec<Vec<u8>> = Vec::new();
+    let mut stale_ingress_keys: Vec<Vec<u8>> = Vec::new();
+
+    for key in egress_map.keys() {
+        if let Ok(Some(value)) = egress_map.lookup(&key, MapFlags::ANY) {
+            // nat4_egress_mapping_value_v3.addr is at offset 0, 4 bytes (big-endian).
+            if value.len() >= 4 && value[..4] == old_ip_bytes {
+                stale_egress_keys.push(key.clone());
+                // Build the corresponding ingress key: flip gress and use the
+                // mapped (WAN-side) addr/port as from_addr/from_port.
+                // Key layout: gress(1) + l4proto(1) + from_port(2) + from_addr(4) = 8 bytes
+                if key.len() >= 8 && value.len() >= 6 {
+                    let mut ingress_key = key.clone();
+                    ingress_key[0] = crate::NAT_MAPPING_INGRESS;
+                    // from_port = mapped port (value offset 4, 2 bytes)
+                    ingress_key[2..4].copy_from_slice(&value[4..6]);
+                    // from_addr = mapped addr (value offset 0, 4 bytes)
+                    ingress_key[4..8].copy_from_slice(&value[..4]);
+                    stale_ingress_keys.push(ingress_key);
+                }
+            }
+        }
+    }
+
+    let flushed = stale_egress_keys.len();
+    for key in &stale_egress_keys {
+        let _ = egress_map.delete(key);
+    }
+    for key in &stale_ingress_keys {
+        let _ = ingress_map.delete(key);
+    }
+
+    if flushed > 0 {
+        tracing::info!("flushed {flushed} stale NAT4 egress mappings for old WAN IP {old_wan_ip}");
+    }
+    flushed
 }
 
 /// Compute the NPT (Network Prefix Translation) mask for IPv6 prefix translation.

--- a/landscape-ebpf/src/stages/nat.rs
+++ b/landscape-ebpf/src/stages/nat.rs
@@ -135,7 +135,7 @@ pub fn attach_tc_nat(ifindex: u32, has_mac: bool, config: &NatConfig) -> LdEbpfR
     pin_and_reuse_map(&mut open_skel.maps.nat4_static_map, &MAP_PATHS.nat4_static_map)?;
     pin_and_reuse_map(&mut open_skel.maps.nat_metric_events, &MAP_PATHS.nat_metric_events)?;
 
-    let skel = bpf_ctx!(open_skel.load(), "load tc_nat skeleton")?;
+    let mut skel = bpf_ctx!(open_skel.load(), "load tc_nat skeleton")?;
 
     seed_runtime_queues(
         &skel.maps.nat4_tcp_port_queue,
@@ -143,6 +143,23 @@ pub fn attach_tc_nat(ifindex: u32, has_mac: bool, config: &NatConfig) -> LdEbpfR
         &skel.maps.nat4_icmp_port_queue,
         config,
     );
+
+    let _ = std::fs::remove_file(&MAP_PATHS.nat4_egress_dyn_map);
+    let _ = std::fs::remove_file(&MAP_PATHS.nat4_ingress_dyn_map);
+    skel.maps
+        .nat4_egress_dyn_map
+        .pin(MAP_PATHS.nat4_egress_dyn_map.to_str().unwrap_or_default())
+        .map_err(|e| crate::bpf_error::LandscapeEbpfError::Context {
+        context: "pin nat4_egress_dyn_map".to_string(),
+        source: e,
+    })?;
+    skel.maps
+        .nat4_ingress_dyn_map
+        .pin(MAP_PATHS.nat4_ingress_dyn_map.to_str().unwrap_or_default())
+        .map_err(|e| crate::bpf_error::LandscapeEbpfError::Context {
+            context: "pin nat4_ingress_dyn_map".to_string(),
+            source: e,
+        })?;
 
     let entry = StageEntry {
         wan_ingress_prog_fd: skel.progs.tc_nat_wan_ingress.as_fd().as_raw_fd(),
@@ -209,7 +226,7 @@ fn init_nat_xdp_unified(
     pin_and_reuse_map(&mut tc_open.maps.nat4_static_map, &MAP_PATHS.nat4_static_map)?;
     pin_and_reuse_map(&mut tc_open.maps.nat_metric_events, &MAP_PATHS.nat_metric_events)?;
 
-    let tc_skel = bpf_ctx!(tc_open.load(), "load tc_nat skeleton")?;
+    let mut tc_skel = bpf_ctx!(tc_open.load(), "load tc_nat skeleton")?;
 
     seed_runtime_queues(
         &tc_skel.maps.nat4_tcp_port_queue,
@@ -217,6 +234,26 @@ fn init_nat_xdp_unified(
         &tc_skel.maps.nat4_icmp_port_queue,
         config,
     );
+
+    // Pin dynamic NAT maps so userspace can flush stale entries on WAN IP change.
+    let _ = std::fs::remove_file(&MAP_PATHS.nat4_egress_dyn_map);
+    let _ = std::fs::remove_file(&MAP_PATHS.nat4_ingress_dyn_map);
+    tc_skel
+        .maps
+        .nat4_egress_dyn_map
+        .pin(MAP_PATHS.nat4_egress_dyn_map.to_str().unwrap_or_default())
+        .map_err(|e| crate::bpf_error::LandscapeEbpfError::Context {
+            context: "pin nat4_egress_dyn_map".to_string(),
+            source: e,
+        })?;
+    tc_skel
+        .maps
+        .nat4_ingress_dyn_map
+        .pin(MAP_PATHS.nat4_ingress_dyn_map.to_str().unwrap_or_default())
+        .map_err(|e| crate::bpf_error::LandscapeEbpfError::Context {
+            context: "pin nat4_ingress_dyn_map".to_string(),
+            source: e,
+        })?;
 
     // ── 2. Open XDP nat, reuse TC's runtime map FDs ──
 

--- a/landscape-ebpf/src/tests/nat/v4/flush_stale_nat4.rs
+++ b/landscape-ebpf/src/tests/nat/v4/flush_stale_nat4.rs
@@ -1,0 +1,275 @@
+use std::{
+    mem::MaybeUninit,
+    net::{IpAddr, Ipv4Addr},
+};
+
+use landscape_common::net::MacAddr;
+use libbpf_rs::{
+    skel::{OpenSkel, SkelBuilder as _},
+    MapCore, MapFlags,
+};
+
+use crate::{
+    map_setting::{add_wan_ip, flush_nat4_dyn_maps_by_old_ip, nat::NatMappingKeyV4},
+    stages::nat::tc_nat_skel::{types, TcNatSkelBuilder},
+    NAT_MAPPING_EGRESS, NAT_MAPPING_INGRESS,
+};
+
+const OLD_WAN_IP: Ipv4Addr = Ipv4Addr::new(100, 71, 54, 57);
+const NEW_WAN_IP: Ipv4Addr = Ipv4Addr::new(100, 72, 176, 49);
+const LAN_HOST_A: Ipv4Addr = Ipv4Addr::new(192, 168, 100, 16);
+const LAN_HOST_B: Ipv4Addr = Ipv4Addr::new(192, 168, 100, 20);
+const REMOTE_WG: Ipv4Addr = Ipv4Addr::new(193, 112, 55, 37);
+const REMOTE_TS: Ipv4Addr = Ipv4Addr::new(81, 71, 155, 152);
+const REMOTE_HTTP: Ipv4Addr = Ipv4Addr::new(1, 1, 1, 1);
+const IFINDEX: u32 = 6;
+
+fn insert_egress_ingress_pair<M1: MapCore, M2: MapCore>(
+    egress_map: &M1,
+    ingress_map: &M2,
+    l4proto: u8,
+    lan_addr: Ipv4Addr,
+    lan_port: u16,
+    nat_addr: Ipv4Addr,
+    nat_port: u16,
+    remote_addr: Ipv4Addr,
+    remote_port: u16,
+) {
+    let egress_key = NatMappingKeyV4 {
+        gress: NAT_MAPPING_EGRESS,
+        l4proto,
+        from_port: lan_port.to_be(),
+        from_addr: lan_addr.to_bits().to_be(),
+    };
+    let mut egress_val = types::nat4_egress_mapping_value_v3::default();
+    egress_val.addr = nat_addr.to_bits().to_be();
+    egress_val.trigger_addr = remote_addr.to_bits().to_be();
+    egress_val.port = nat_port.to_be();
+    egress_val.trigger_port = remote_port.to_be();
+    egress_val.is_allow_reuse = 1;
+
+    let ingress_key = NatMappingKeyV4 {
+        gress: NAT_MAPPING_INGRESS,
+        l4proto,
+        from_port: nat_port.to_be(),
+        from_addr: nat_addr.to_bits().to_be(),
+    };
+    let ingress_val = types::nat4_mapping_value_v3 {
+        state_ref: ((1u64) << 56) | 1,
+        addr: lan_addr.to_bits().to_be(),
+        trigger_addr: remote_addr.to_bits().to_be(),
+        port: lan_port.to_be(),
+        trigger_port: remote_port.to_be(),
+        generation: 1,
+        _pad: 0,
+        is_allow_reuse: 1,
+    };
+
+    egress_map
+        .update(
+            unsafe { plain::as_bytes(&egress_key) },
+            unsafe { plain::as_bytes(&egress_val) },
+            MapFlags::ANY,
+        )
+        .expect("insert egress mapping");
+    ingress_map
+        .update(
+            unsafe { plain::as_bytes(&ingress_key) },
+            unsafe { plain::as_bytes(&ingress_val) },
+            MapFlags::ANY,
+        )
+        .expect("insert ingress mapping");
+}
+
+fn egress_exists<M: MapCore>(map: &M, l4proto: u8, lan_addr: Ipv4Addr, lan_port: u16) -> bool {
+    let key = NatMappingKeyV4 {
+        gress: NAT_MAPPING_EGRESS,
+        l4proto,
+        from_port: lan_port.to_be(),
+        from_addr: lan_addr.to_bits().to_be(),
+    };
+    map.lookup(unsafe { plain::as_bytes(&key) }, MapFlags::ANY).ok().flatten().is_some()
+}
+
+fn ingress_exists<M: MapCore>(map: &M, l4proto: u8, nat_addr: Ipv4Addr, nat_port: u16) -> bool {
+    let key = NatMappingKeyV4 {
+        gress: NAT_MAPPING_INGRESS,
+        l4proto,
+        from_port: nat_port.to_be(),
+        from_addr: nat_addr.to_bits().to_be(),
+    };
+    map.lookup(unsafe { plain::as_bytes(&key) }, MapFlags::ANY).ok().flatten().is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::nat::NAT_V3_TEST_LOCK;
+
+    #[test]
+    fn flush_removes_only_stale_mappings() {
+        let _guard = NAT_V3_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let mut builder = TcNatSkelBuilder::default();
+        let pin_root = crate::tests::nat::isolated_pin_root("nat-v4-flush-stale");
+        builder.object_builder_mut().pin_root_path(&pin_root).unwrap();
+        let mut open_object = MaybeUninit::uninit();
+        let open_skel = builder.open(&mut open_object).unwrap();
+        let skel = open_skel.load().unwrap();
+
+        add_wan_ip(
+            &skel.maps.wan_ip_binding,
+            IFINDEX,
+            IpAddr::V4(OLD_WAN_IP),
+            None,
+            32,
+            Some(MacAddr::broadcast()),
+        );
+
+        // Insert mappings with OLD WAN IP (stale after redial):
+        // WireGuard flow: LAN_HOST_A:58648 -> OLD_WAN_IP:32787 -> REMOTE_WG:51820 (UDP)
+        insert_egress_ingress_pair(
+            &skel.maps.nat4_egress_dyn_map,
+            &skel.maps.nat4_ingress_dyn_map,
+            17, // UDP
+            LAN_HOST_A,
+            58648,
+            OLD_WAN_IP,
+            32787,
+            REMOTE_WG,
+            51820,
+        );
+        // Tailscale flow: LAN_HOST_A:60133 -> OLD_WAN_IP:32775 -> REMOTE_TS:41641 (UDP)
+        insert_egress_ingress_pair(
+            &skel.maps.nat4_egress_dyn_map,
+            &skel.maps.nat4_ingress_dyn_map,
+            17,
+            LAN_HOST_A,
+            60133,
+            OLD_WAN_IP,
+            32775,
+            REMOTE_TS,
+            41641,
+        );
+
+        // Insert mappings with NEW WAN IP (should survive flush):
+        // HTTP flow: LAN_HOST_B:44000 -> NEW_WAN_IP:40000 -> REMOTE_HTTP:443 (TCP)
+        insert_egress_ingress_pair(
+            &skel.maps.nat4_egress_dyn_map,
+            &skel.maps.nat4_ingress_dyn_map,
+            6, // TCP
+            LAN_HOST_B,
+            44000,
+            NEW_WAN_IP,
+            40000,
+            REMOTE_HTTP,
+            443,
+        );
+        // DNS flow: LAN_HOST_B:55555 -> NEW_WAN_IP:40001 -> REMOTE_HTTP:53 (UDP)
+        insert_egress_ingress_pair(
+            &skel.maps.nat4_egress_dyn_map,
+            &skel.maps.nat4_ingress_dyn_map,
+            17,
+            LAN_HOST_B,
+            55555,
+            NEW_WAN_IP,
+            40001,
+            REMOTE_HTTP,
+            53,
+        );
+
+        // Verify all 4 mappings exist before flush.
+        assert!(egress_exists(&skel.maps.nat4_egress_dyn_map, 17, LAN_HOST_A, 58648));
+        assert!(egress_exists(&skel.maps.nat4_egress_dyn_map, 17, LAN_HOST_A, 60133));
+        assert!(egress_exists(&skel.maps.nat4_egress_dyn_map, 6, LAN_HOST_B, 44000));
+        assert!(egress_exists(&skel.maps.nat4_egress_dyn_map, 17, LAN_HOST_B, 55555));
+        assert!(ingress_exists(&skel.maps.nat4_ingress_dyn_map, 17, OLD_WAN_IP, 32787));
+        assert!(ingress_exists(&skel.maps.nat4_ingress_dyn_map, 17, OLD_WAN_IP, 32775));
+        assert!(ingress_exists(&skel.maps.nat4_ingress_dyn_map, 6, NEW_WAN_IP, 40000));
+        assert!(ingress_exists(&skel.maps.nat4_ingress_dyn_map, 17, NEW_WAN_IP, 40001));
+
+        // Flush mappings for OLD_WAN_IP.
+        let flushed = flush_nat4_dyn_maps_by_old_ip(
+            &skel.maps.nat4_egress_dyn_map,
+            &skel.maps.nat4_ingress_dyn_map,
+            OLD_WAN_IP,
+        );
+
+        // Should have flushed exactly 2 stale mappings.
+        assert_eq!(flushed, 2, "expected 2 stale mappings flushed");
+
+        // Stale mappings (old WAN IP) should be gone.
+        assert!(
+            !egress_exists(&skel.maps.nat4_egress_dyn_map, 17, LAN_HOST_A, 58648),
+            "WG egress mapping should be deleted"
+        );
+        assert!(
+            !egress_exists(&skel.maps.nat4_egress_dyn_map, 17, LAN_HOST_A, 60133),
+            "TS egress mapping should be deleted"
+        );
+        assert!(
+            !ingress_exists(&skel.maps.nat4_ingress_dyn_map, 17, OLD_WAN_IP, 32787),
+            "WG ingress mapping should be deleted"
+        );
+        assert!(
+            !ingress_exists(&skel.maps.nat4_ingress_dyn_map, 17, OLD_WAN_IP, 32775),
+            "TS ingress mapping should be deleted"
+        );
+
+        // Fresh mappings (new WAN IP) should still exist.
+        assert!(
+            egress_exists(&skel.maps.nat4_egress_dyn_map, 6, LAN_HOST_B, 44000),
+            "HTTP egress mapping should survive"
+        );
+        assert!(
+            egress_exists(&skel.maps.nat4_egress_dyn_map, 17, LAN_HOST_B, 55555),
+            "DNS egress mapping should survive"
+        );
+        assert!(
+            ingress_exists(&skel.maps.nat4_ingress_dyn_map, 6, NEW_WAN_IP, 40000),
+            "HTTP ingress mapping should survive"
+        );
+        assert!(
+            ingress_exists(&skel.maps.nat4_ingress_dyn_map, 17, NEW_WAN_IP, 40001),
+            "DNS ingress mapping should survive"
+        );
+    }
+
+    #[test]
+    fn flush_noop_when_no_stale_entries() {
+        let _guard = NAT_V3_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let mut builder = TcNatSkelBuilder::default();
+        let pin_root = crate::tests::nat::isolated_pin_root("nat-v4-flush-noop");
+        builder.object_builder_mut().pin_root_path(&pin_root).unwrap();
+        let mut open_object = MaybeUninit::uninit();
+        let open_skel = builder.open(&mut open_object).unwrap();
+        let skel = open_skel.load().unwrap();
+
+        // Only insert mappings with NEW_WAN_IP.
+        insert_egress_ingress_pair(
+            &skel.maps.nat4_egress_dyn_map,
+            &skel.maps.nat4_ingress_dyn_map,
+            17,
+            LAN_HOST_A,
+            58648,
+            NEW_WAN_IP,
+            32787,
+            REMOTE_WG,
+            51820,
+        );
+
+        // Flush for an IP that has no entries.
+        let flushed = flush_nat4_dyn_maps_by_old_ip(
+            &skel.maps.nat4_egress_dyn_map,
+            &skel.maps.nat4_ingress_dyn_map,
+            OLD_WAN_IP,
+        );
+
+        assert_eq!(flushed, 0, "should flush nothing");
+        assert!(
+            egress_exists(&skel.maps.nat4_egress_dyn_map, 17, LAN_HOST_A, 58648),
+            "existing mapping should be untouched"
+        );
+    }
+}

--- a/landscape-ebpf/src/tests/nat/v4/mod.rs
+++ b/landscape-ebpf/src/tests/nat/v4/mod.rs
@@ -1,4 +1,5 @@
 mod dynamic_nat_v3;
 mod dynamic_nat_v3_timer;
 mod egress_smoke_v4;
+mod flush_stale_nat4;
 mod static_nat_v3;


### PR DESCRIPTION
### 修复内容

WAN IP 变化时（PPPoE 重拨、DHCP 换址），用户态自动清理 `nat4_egress_dyn_map`（及对应 `nat4_ingress_dyn_map`）中 `mapped_src == 旧 WAN IP` 的条目。下一个出站包会自然创建新映射拿到新地址。

### 改动

1. **`landscape-ebpf/src/lib.rs`** — 在 `LandscapeMapPath` 中为动态 NAT map 添加 pinned path
2. **`landscape-ebpf/src/stages/nat.rs`** — NAT 初始化时 pin `nat4_egress_dyn_map` 和 `nat4_ingress_dyn_map` 到 bpffs，使用户态可以通过 `from_pinned_path` 访问
3. **`landscape-ebpf/src/map_setting/mod.rs`** — 在 `add_ipv4_wan_ip()` 中：先 lookup 旧 WAN IP，若与新 IP 不同则遍历 egress map 删除旧条目及对应的 ingress 条目
4. **`landscape-ebpf/src/tests/nat/v4/flush_stale_nat4.rs`** — 集成测试：验证 flush 只删旧 IP 映射、保留新 IP 映射

### 设计取舍

- **选择性删除而非全表 flush**：只删 `value.addr == old_ip` 的条目，避免打断正常流量
- **同时清理 ingress map**：避免孤儿条目导致入站 DNAT 错误
- **Pin 动态 map 到 bpffs**：此前这些 map 只通过 `reuse_fd` 在 TC/XDP 间共享，用户态无法访问。Pin 后不影响 eBPF 侧行为
- **不改 eBPF 程序本身**：纯用户态修复

### 测试

- `cargo build --release --features duckdb-bundled` ✅
- `cargo clippy -p landscape-ebpf --release` — 无新 warning/error
- 集成测试（需 root 加载 eBPF skel）：
  - `flush_removes_only_stale_mappings` — 插入 4 条映射（2 旧 2 新），flush 后旧的被删、新的保留 ✅
  - `flush_noop_when_no_stale_entries` — 无 stale 条目时 flush 不影响任何东西 ✅

Closes #214