### PR TITLE
修复 DuckDB 持久化:启动回放残留 WAL 崩溃循环 + bucket 写入假批量

### DIFF
--- a/landscape/src/metric/duckdb/cold.rs
+++ b/landscape/src/metric/duckdb/cold.rs
@@ -1,22 +1,30 @@
-use duckdb::{params, params_from_iter, DuckdbConnectionManager};
+use duckdb::{params_from_iter, DuckdbConnectionManager};
 use landscape_common::config::MetricRuntimeConfig;
 use landscape_common::metric::dns::DnsMetric;
 use landscape_core::time::get_current_time_ms;
+use std::collections::HashMap;
 use std::time::Instant;
 
 use crate::metric::cold::{BucketPersistStats, ColdCleanupStats, ColdStore, DnsPersistStats};
-use crate::metric::ingest::{clean_ip_string, BucketWrite, IfaceBucketWrite, MS_PER_DAY};
+use crate::metric::ingest::{
+    clean_ip_string, BucketKind, BucketWrite, IfaceBucketWrite, MS_PER_DAY,
+};
 
 use super::connect::{cleanup, schema as connect_schema};
 use super::dns::schema as dns_schema;
 
 const DNS_METRIC_COLUMNS: usize = 9;
+/// Rows per multi-row bucket upsert statement. Bounds the statement size and
+/// the prepared-statement parameter count while keeping DuckDB on its
+/// vectorized execution path.
+const BUCKET_UPSERT_CHUNK_ROWS: usize = 1024;
 
 /// DuckDB-backed cold history store.
 ///
-/// All writes are batch-oriented: bucket upserts run inside a single
-/// transaction with reused prepared statements, and DNS metrics are inserted
-/// as one multi-row statement per batch.
+/// All writes are batch-oriented: bucket upserts are grouped per table,
+/// folded by primary key, and flushed as multi-row `INSERT ... SELECT`
+/// statements inside a single transaction, and DNS metrics are inserted as
+/// one multi-row statement per batch.
 pub(crate) struct DuckdbColdStore {
     pool: r2d2::Pool<DuckdbConnectionManager>,
 }
@@ -25,6 +33,180 @@ impl DuckdbColdStore {
     pub(crate) fn new(pool: r2d2::Pool<DuckdbConnectionManager>) -> Self {
         Self { pool }
     }
+}
+
+/// Column layout of one merged `conn_metrics_*` row. The primary key
+/// occupies the first three columns (`create_time`, `cpu_id`,
+/// `report_time`); the constants below index the merged payload columns.
+mod conn_columns {
+    pub(crate) const IFINDEX: usize = 3;
+    pub(crate) const INGRESS_BYTES: usize = 4;
+    pub(crate) const INGRESS_PACKETS: usize = 5;
+    pub(crate) const EGRESS_BYTES: usize = 6;
+    pub(crate) const EGRESS_PACKETS: usize = 7;
+    pub(crate) const STATUS: usize = 8;
+    pub(crate) const CREATE_TIME_MS: usize = 9;
+}
+
+/// Column layout of one merged `iface_metrics_5s` row. The primary key
+/// occupies the first two columns (`ifindex`, `report_time`).
+mod iface_columns {
+    pub(crate) const INGRESS_BYTES: usize = 2;
+    pub(crate) const INGRESS_PACKETS: usize = 3;
+    pub(crate) const EGRESS_BYTES: usize = 4;
+    pub(crate) const EGRESS_PACKETS: usize = 5;
+    pub(crate) const ACTIVE_CONNS: usize = 6;
+}
+
+/// Collapse bucket rows sharing a primary key into one row, applying exactly
+/// the merge the single-row upsert applied per incoming row: counters and
+/// `create_time_ms` keep the maximum, and the `ifindex` comes from the latest
+/// `create_time_ms` seen (arrival order breaks ties).
+///
+/// A vectorized multi-row `INSERT ... ON CONFLICT` must not receive the same
+/// key twice within one statement: DuckDB resolves in-statement duplicate
+/// keys differently from the row-by-row merge, so duplicates are folded here
+/// before the statement is built.
+fn aggregate_conn_bucket_rows(rows: &[&BucketWrite]) -> Vec<[i64; connect_schema::BUCKET_COLUMNS]> {
+    let mut slot_by_key: HashMap<(u64, u32, u64), usize> = HashMap::with_capacity(rows.len());
+    let mut merged: Vec<[i64; connect_schema::BUCKET_COLUMNS]> = Vec::with_capacity(rows.len());
+    for bucket in rows {
+        let status: u8 = bucket.metric.status.clone().into();
+        let row = [
+            bucket.metric.key.create_time as i64,
+            bucket.metric.key.cpu_id as i64,
+            bucket.bucket_report_time as i64,
+            bucket.metric.ifindex as i64,
+            bucket.metric.ingress_bytes as i64,
+            bucket.metric.ingress_packets as i64,
+            bucket.metric.egress_bytes as i64,
+            bucket.metric.egress_packets as i64,
+            status as i64,
+            bucket.metric.create_time_ms as i64,
+        ];
+        let key =
+            (bucket.metric.key.create_time, bucket.metric.key.cpu_id, bucket.bucket_report_time);
+        match slot_by_key.get(&key) {
+            Some(&slot) => {
+                let existing = &mut merged[slot];
+                if row[conn_columns::CREATE_TIME_MS] >= existing[conn_columns::CREATE_TIME_MS] {
+                    existing[conn_columns::IFINDEX] = row[conn_columns::IFINDEX];
+                }
+                for column in [
+                    conn_columns::INGRESS_BYTES,
+                    conn_columns::INGRESS_PACKETS,
+                    conn_columns::EGRESS_BYTES,
+                    conn_columns::EGRESS_PACKETS,
+                    conn_columns::STATUS,
+                    conn_columns::CREATE_TIME_MS,
+                ] {
+                    existing[column] = existing[column].max(row[column]);
+                }
+            }
+            None => {
+                slot_by_key.insert(key, merged.len());
+                merged.push(row);
+            }
+        }
+    }
+    merged
+}
+
+/// Collapse iface bucket rows sharing `(ifindex, report_time)`, applying the
+/// additive merge the single-row upsert applied per incoming row. Counter
+/// overflows saturate instead of failing the batch; the SQL-side `+` on
+/// existing table rows would error, but 5s-bucket byte/packet deltas cannot
+/// realistically reach `i64::MAX`.
+fn aggregate_iface_bucket_rows(
+    rows: &[IfaceBucketWrite],
+) -> Vec<[i64; connect_schema::IFACE_BUCKET_COLUMNS]> {
+    let mut slot_by_key: HashMap<(u32, u64), usize> = HashMap::with_capacity(rows.len());
+    let mut merged: Vec<[i64; connect_schema::IFACE_BUCKET_COLUMNS]> =
+        Vec::with_capacity(rows.len());
+    for bucket in rows {
+        let row = [
+            bucket.ifindex as i64,
+            bucket.report_time as i64,
+            bucket.ingress_bytes as i64,
+            bucket.ingress_packets as i64,
+            bucket.egress_bytes as i64,
+            bucket.egress_packets as i64,
+            bucket.active_conns as i64,
+        ];
+        let key = (bucket.ifindex, bucket.report_time);
+        match slot_by_key.get(&key) {
+            Some(&slot) => {
+                let existing = &mut merged[slot];
+                for column in [
+                    iface_columns::INGRESS_BYTES,
+                    iface_columns::INGRESS_PACKETS,
+                    iface_columns::EGRESS_BYTES,
+                    iface_columns::EGRESS_PACKETS,
+                ] {
+                    existing[column] = existing[column].saturating_add(row[column]);
+                }
+                existing[iface_columns::ACTIVE_CONNS] =
+                    existing[iface_columns::ACTIVE_CONNS].max(row[iface_columns::ACTIVE_CONNS]);
+            }
+            None => {
+                slot_by_key.insert(key, merged.len());
+                merged.push(row);
+            }
+        }
+    }
+    merged
+}
+
+/// Execute the chunked multi-row upserts for one table, preparing (and then
+/// reusing) one statement per distinct chunk length: a batch produces at
+/// most the full-chunk statement plus one remainder statement.
+fn execute_conn_bucket_chunks(
+    tx: &duckdb::Transaction<'_>,
+    table: &str,
+    rows: &[[i64; connect_schema::BUCKET_COLUMNS]],
+) -> Result<(), String> {
+    let mut prepared_by_len: HashMap<usize, duckdb::Statement<'_>> = HashMap::new();
+    for chunk in rows.chunks(BUCKET_UPSERT_CHUNK_ROWS) {
+        if !prepared_by_len.contains_key(&chunk.len()) {
+            let sql = connect_schema::upsert_metric_bucket_values_sql(table, chunk.len());
+            let statement = tx.prepare(&sql).map_err(|error| {
+                format!("failed to prepare cold bucket upsert for {}: {}", table, error)
+            })?;
+            prepared_by_len.insert(chunk.len(), statement);
+        }
+        let statement = prepared_by_len.get_mut(&chunk.len()).expect("prepared above");
+        statement.execute(params_from_iter(chunk.iter().flatten().copied())).map_err(|error| {
+            format!(
+                "failed to write cold bucket batch of {} rows into {}: {}",
+                chunk.len(),
+                table,
+                error
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// Iface counterpart of [`execute_conn_bucket_chunks`].
+fn execute_iface_bucket_chunks(
+    tx: &duckdb::Transaction<'_>,
+    rows: &[[i64; connect_schema::IFACE_BUCKET_COLUMNS]],
+) -> Result<(), String> {
+    let mut prepared_by_len: HashMap<usize, duckdb::Statement<'_>> = HashMap::new();
+    for chunk in rows.chunks(BUCKET_UPSERT_CHUNK_ROWS) {
+        if !prepared_by_len.contains_key(&chunk.len()) {
+            let sql = connect_schema::upsert_iface_metric_bucket_values_sql(chunk.len());
+            let statement = tx.prepare(&sql).map_err(|error| {
+                format!("failed to prepare cold iface bucket upsert: {}", error)
+            })?;
+            prepared_by_len.insert(chunk.len(), statement);
+        }
+        let statement = prepared_by_len.get_mut(&chunk.len()).expect("prepared above");
+        statement.execute(params_from_iter(chunk.iter().flatten().copied())).map_err(|error| {
+            format!("failed to write cold iface bucket batch of {} rows: {}", chunk.len(), error)
+        })?;
+    }
+    Ok(())
 }
 
 impl ColdStore for DuckdbColdStore {
@@ -46,65 +228,19 @@ impl ColdStore for DuckdbColdStore {
             format!("failed to begin cold duckdb bucket transaction: {}", error)
         })?;
 
-        if !bucket_writes.is_empty() {
-            let mut prepared_table: Option<&str> = None;
-            let mut prepared_stmt: Option<duckdb::Statement<'_>> = None;
-            for bucket in bucket_writes {
-                let table = bucket.kind.table_name();
-                if prepared_table != Some(table) {
-                    prepared_stmt = Some(
-                        tx.prepare(&connect_schema::upsert_metric_bucket_values_sql(table))
-                            .map_err(|error| {
-                                format!(
-                                    "failed to prepare cold bucket upsert for {}: {}",
-                                    table, error
-                                )
-                            })?,
-                    );
-                    prepared_table = Some(table);
-                }
-                let status: u8 = bucket.metric.status.clone().into();
-                prepared_stmt
-                    .as_mut()
-                    .expect("prepared bucket upsert")
-                    .execute(params![
-                        bucket.metric.key.create_time as i64,
-                        bucket.metric.key.cpu_id as i64,
-                        bucket.bucket_report_time as i64,
-                        bucket.metric.ifindex as i64,
-                        bucket.metric.ingress_bytes as i64,
-                        bucket.metric.ingress_packets as i64,
-                        bucket.metric.egress_bytes as i64,
-                        bucket.metric.egress_packets as i64,
-                        status as i64,
-                        bucket.metric.create_time_ms as i64,
-                    ])
-                    .map_err(|error| {
-                        format!("failed to write cold bucket row into {}: {}", table, error)
-                    })?;
+        for kind in [BucketKind::Minute, BucketKind::Hour, BucketKind::Day] {
+            let table_rows: Vec<&BucketWrite> =
+                bucket_writes.iter().filter(|bucket| bucket.kind == kind).collect();
+            if table_rows.is_empty() {
+                continue;
             }
-            drop(prepared_stmt);
+            let merged_rows = aggregate_conn_bucket_rows(&table_rows);
+            execute_conn_bucket_chunks(&tx, kind.table_name(), &merged_rows)?;
         }
 
         if !iface_bucket_writes.is_empty() {
-            let mut prepared_stmt =
-                tx.prepare(&connect_schema::upsert_iface_metric_bucket_values_sql()).map_err(
-                    |error| format!("failed to prepare cold iface bucket upsert: {}", error),
-                )?;
-            for bucket in iface_bucket_writes {
-                prepared_stmt
-                    .execute(params![
-                        bucket.ifindex as i64,
-                        bucket.report_time as i64,
-                        bucket.ingress_bytes as i64,
-                        bucket.ingress_packets as i64,
-                        bucket.egress_bytes as i64,
-                        bucket.egress_packets as i64,
-                        bucket.active_conns as i64,
-                    ])
-                    .map_err(|error| format!("failed to write cold iface bucket row: {}", error))?;
-            }
-            drop(prepared_stmt);
+            let merged_rows = aggregate_iface_bucket_rows(iface_bucket_writes);
+            execute_iface_bucket_chunks(&tx, &merged_rows)?;
         }
 
         tx.commit().map_err(|error| {

--- a/landscape/src/metric/duckdb/connect/schema.rs
+++ b/landscape/src/metric/duckdb/connect/schema.rs
@@ -1,14 +1,51 @@
 use duckdb::Connection;
 
-#[allow(clippy::too_many_arguments)]
-pub fn upsert_metric_bucket_values_sql(table: &str) -> String {
+/// Number of columns in one `conn_metrics_*` bucket row. Shared with the
+/// cold store so the Rust row layout cannot drift from the SQL column list.
+pub(crate) const BUCKET_COLUMNS: usize = 10;
+/// Number of columns in one `iface_metrics_5s` bucket row; see
+/// [`BUCKET_COLUMNS`].
+pub(crate) const IFACE_BUCKET_COLUMNS: usize = 7;
+
+fn multi_row_values(row_count: usize, column_count: usize) -> String {
+    (0..row_count)
+        .map(|row| {
+            let base = row * column_count;
+            (1..=column_count)
+                .map(|column| format!("?{}", base + column))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .map(|row| format!("({row})"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Multi-row bucket upsert.
+///
+/// DuckDB executes prepared statements row by row, so a loop of single-row
+/// upserts is interpreted once per row. Batching the rows into one
+/// `INSERT ... SELECT` from a `VALUES` list keeps the whole batch on the
+/// vectorized execution path. The `VALUES` list must stay wrapped in a
+/// subquery: a flat multi-row `INSERT ... VALUES ... ON CONFLICT` fails to
+/// bind once the row count grows past a few hundred rows.
+pub fn upsert_metric_bucket_values_sql(table: &str, row_count: usize) -> String {
+    let values = multi_row_values(row_count, BUCKET_COLUMNS);
     format!(
         "
         INSERT INTO {table} (
             create_time, cpu_id, report_time, ifindex,
             ingress_bytes, ingress_packets, egress_bytes, egress_packets,
             status, create_time_ms
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+        )
+        SELECT create_time, cpu_id, report_time, ifindex,
+               ingress_bytes, ingress_packets, egress_bytes, egress_packets,
+               status, create_time_ms
+        FROM (VALUES {values}) AS batch(
+            create_time, cpu_id, report_time, ifindex,
+            ingress_bytes, ingress_packets, egress_bytes, egress_packets,
+            status, create_time_ms
+        )
         ON CONFLICT (create_time, cpu_id, report_time) DO UPDATE SET
             ifindex = CASE
                 WHEN EXCLUDED.create_time_ms >= {table}.create_time_ms THEN EXCLUDED.ifindex
@@ -24,13 +61,24 @@ pub fn upsert_metric_bucket_values_sql(table: &str) -> String {
     )
 }
 
-pub fn upsert_iface_metric_bucket_values_sql() -> String {
-    "
+/// Multi-row iface bucket upsert; see [`upsert_metric_bucket_values_sql`].
+pub fn upsert_iface_metric_bucket_values_sql(row_count: usize) -> String {
+    let values = multi_row_values(row_count, IFACE_BUCKET_COLUMNS);
+    format!(
+        "
         INSERT INTO iface_metrics_5s (
             ifindex, report_time,
             ingress_bytes, ingress_packets, egress_bytes, egress_packets,
             active_conns
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        )
+        SELECT ifindex, report_time,
+               ingress_bytes, ingress_packets, egress_bytes, egress_packets,
+               active_conns
+        FROM (VALUES {values}) AS batch(
+            ifindex, report_time,
+            ingress_bytes, ingress_packets, egress_bytes, egress_packets,
+            active_conns
+        )
         ON CONFLICT (ifindex, report_time) DO UPDATE SET
             ingress_bytes = iface_metrics_5s.ingress_bytes + EXCLUDED.ingress_bytes,
             ingress_packets = iface_metrics_5s.ingress_packets + EXCLUDED.ingress_packets,
@@ -38,7 +86,7 @@ pub fn upsert_iface_metric_bucket_values_sql() -> String {
             egress_packets = iface_metrics_5s.egress_packets + EXCLUDED.egress_packets,
             active_conns = GREATEST(iface_metrics_5s.active_conns, EXCLUDED.active_conns)
     "
-    .to_string()
+    )
 }
 
 pub fn create_metrics_table(conn: &Connection) -> duckdb::Result<()> {

--- a/landscape/src/metric/duckdb/store.rs
+++ b/landscape/src/metric/duckdb/store.rs
@@ -54,6 +54,21 @@ const DUCKDB_POOL_MIN_IDLE: u32 = 1;
 const COLD_RETRY_DELAY_SECS: u64 = 5;
 const DNS_BATCH_MAX_ROWS: usize = 500;
 const DNS_BATCH_FLUSH_TIMEOUT_SECS: u64 = 5;
+/// WAL files above this size are replayed under an elevated memory limit
+/// before the pool opens the database with the configured limit.
+const WAL_PRECHECKPOINT_THRESHOLD_BYTES: u64 = 1024 * 1024;
+/// Minimum memory limit (MB) used while replaying a large WAL. A 16MB WAL
+/// (the `wal_autocheckpoint` threshold) can need roughly 500MB to replay, so
+/// this must stay comfortably above that even when the configured limit is
+/// the 256MB default.
+const WAL_REPLAY_MIN_MEMORY_MB: usize = 1024;
+/// Replay memory needed per WAL byte. Observed at 20-31x on insert-style WAL
+/// replayed against multi-million-row primary key indexes; `wal_autocheckpoint`
+/// only bounds the WAL at commit boundaries, and a single large transaction
+/// (one `persist_buckets` batch is one transaction) can leave more behind, so
+/// the replay budget must scale with the leftover WAL size instead of relying
+/// on the floor alone.
+const WAL_REPLAY_MEMORY_PER_WAL_BYTE: usize = 32;
 
 #[derive(Debug)]
 enum ColdEvent {
@@ -61,12 +76,19 @@ enum ColdEvent {
     Dns(DnsMetric),
 }
 
-fn build_duckdb_config(config: &MetricRuntimeConfig) -> StoreInitResult<duckdb::Config> {
+fn build_duckdb_config_with_memory(
+    config: &MetricRuntimeConfig,
+    max_memory_mb: usize,
+) -> StoreInitResult<duckdb::Config> {
     duckdb::Config::default()
         .threads(config.db_max_threads as i64)
         .map_err(|error| format!("failed to configure duckdb threads: {}", error))?
-        .max_memory(&format!("{}MB", config.db_max_memory_mb))
+        .max_memory(&format!("{}MB", max_memory_mb))
         .map_err(|error| format!("failed to configure duckdb max memory: {}", error))
+}
+
+fn build_duckdb_config(config: &MetricRuntimeConfig) -> StoreInitResult<duckdb::Config> {
+    build_duckdb_config_with_memory(config, config.db_max_memory_mb)
 }
 
 fn metric_db_sidecar_paths(db_path: &Path) -> Vec<PathBuf> {
@@ -213,10 +235,89 @@ fn initialize_cold_storage(
     Ok(disk_pool)
 }
 
+fn wal_size_bytes(db_path: &Path) -> u64 {
+    std::fs::metadata(metric_db_wal_path(db_path)).map(|metadata| metadata.len()).unwrap_or_else(
+        |error| {
+            tracing::debug!(
+                "failed to stat metric cold wal {}: {}",
+                metric_db_wal_path(db_path).display(),
+                error,
+            );
+            0
+        },
+    )
+}
+
+/// Replay a large leftover WAL under an elevated memory limit before the
+/// pool opens the database with the configured limit.
+///
+/// DuckDB replays the WAL while opening the database, and replaying the
+/// multi-megabyte WAL left behind by an abnormal shutdown can need several
+/// times the configured memory limit (observed on a long-lived production
+/// database: a 15.6MB WAL peaked at roughly 490MB during replay). Hitting
+/// the limit during replay surfaced as a fatal DuckDB exception that
+/// aborted the process instead of an error the recovery ladder could
+/// catch, so `systemd` restarted the service, the WAL was still there, and
+/// the service crash-looped. Opening once here with a higher limit,
+/// checkpointing, and closing again drains the WAL so the configured pool
+/// can open cheaply and safely.
+fn precheckpoint_large_wal(db_path: &Path, config: &MetricRuntimeConfig) {
+    let wal_size = wal_size_bytes(db_path);
+    if wal_size <= WAL_PRECHECKPOINT_THRESHOLD_BYTES {
+        return;
+    }
+
+    let replay_memory_mb = config
+        .db_max_memory_mb
+        .max(WAL_REPLAY_MIN_MEMORY_MB)
+        .max((wal_size as usize * WAL_REPLAY_MEMORY_PER_WAL_BYTE) / (1024 * 1024));
+    tracing::warn!(
+        "metric cold wal {} is {} bytes (above {} threshold); replaying it under a {}MB memory limit before opening with the configured {}MB limit",
+        metric_db_wal_path(db_path).display(),
+        wal_size,
+        WAL_PRECHECKPOINT_THRESHOLD_BYTES,
+        replay_memory_mb,
+        config.db_max_memory_mb,
+    );
+
+    let result = build_duckdb_config_with_memory(config, replay_memory_mb)
+        .and_then(|replay_config| {
+            DuckdbConnectionManager::file_with_flags(db_path, replay_config)
+                .map_err(|error| format!("failed to open metric duckdb for wal replay: {}", error))
+        })
+        .and_then(|manager| {
+            r2d2::Pool::builder().max_size(1).build(manager).map_err(|error| {
+                format!("failed to create metric duckdb wal replay pool: {}", error)
+            })
+        })
+        .and_then(|pool| {
+            let conn = pool.get().map_err(|error| {
+                format!("failed to get metric duckdb wal replay connection: {}", error)
+            })?;
+            conn.execute("CHECKPOINT", [])
+                .map(|_| ())
+                .map_err(|error| format!("failed to checkpoint metric duckdb wal: {}", error))
+        });
+
+    match result {
+        Ok(()) => tracing::info!(
+            "metric cold wal replayed and checkpointed: {} -> {} bytes",
+            wal_size,
+            wal_size_bytes(db_path),
+        ),
+        Err(error) => tracing::warn!(
+            "failed to precheckpoint metric cold wal at {}: {}; continuing with the normal open path",
+            metric_db_wal_path(db_path).display(),
+            error,
+        ),
+    }
+}
+
 fn initialize_cold_storage_with_recovery(
     db_path: &Path,
     config: &MetricRuntimeConfig,
 ) -> StoreInitResult<r2d2::Pool<DuckdbConnectionManager>> {
+    precheckpoint_large_wal(db_path, config);
     match initialize_cold_storage(db_path, config) {
         Ok(result) => Ok(result),
         Err(initial_error) => {
@@ -1220,6 +1321,312 @@ mod tests {
             conn.query_row("SELECT COUNT(*) FROM conn_metrics_1h", [], |row| row.get(0)).unwrap();
         assert_eq!(minute_count, 5);
         assert_eq!(hour_count, 5);
+    }
+
+    #[test]
+    fn cold_bucket_upsert_batch_merges_conflicting_rows() {
+        init_test_tracing();
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("bucket_merge.duckdb");
+        let pool = initialize_cold_storage(&db_path, &test_metric_config()).unwrap();
+        let cold = DuckdbColdStore::new(pool.clone());
+
+        // Same primary key in one batch: every column must merge exactly like
+        // the single-row upsert did (GREATEST per counter, newer
+        // create_time_ms decides ifindex).
+        let mut older = test_metric(1_000, 1, 60_000, 100, 10, 900, 90);
+        older.ifindex = 11;
+        older.status = ConnectStatusType::Active;
+        older.create_time_ms = 5_000;
+        let mut newer = test_metric(1_000, 1, 60_000, 300, 30, 100, 10);
+        newer.ifindex = 22;
+        newer.status = ConnectStatusType::Disabled;
+        newer.create_time_ms = 9_000;
+        let batch_one = vec![
+            BucketWrite {
+                kind: BucketKind::Minute,
+                metric: older,
+                bucket_report_time: 60_000,
+            },
+            BucketWrite {
+                kind: BucketKind::Minute,
+                metric: newer,
+                bucket_report_time: 60_000,
+            },
+        ];
+        cold.persist_buckets(&batch_one, &[]).unwrap();
+
+        // A later batch with a stale create_time_ms keeps the newer ifindex.
+        let mut stale = test_metric(1_000, 1, 60_000, 50, 5, 50, 5);
+        stale.ifindex = 33;
+        stale.status = ConnectStatusType::Active;
+        stale.create_time_ms = 7_000;
+        let batch_two = vec![BucketWrite {
+            kind: BucketKind::Minute,
+            metric: stale,
+            bucket_report_time: 60_000,
+        }];
+        cold.persist_buckets(&batch_two, &[]).unwrap();
+
+        // An equal create_time_ms takes the later arrival's ifindex, matching
+        // the `>=` in the upsert's CASE expression.
+        let mut tied = test_metric(1_000, 1, 60_000, 10, 1, 10, 1);
+        tied.ifindex = 44;
+        tied.status = ConnectStatusType::Unknow;
+        tied.create_time_ms = 9_000;
+        let batch_three = vec![BucketWrite {
+            kind: BucketKind::Minute,
+            metric: tied,
+            bucket_report_time: 60_000,
+        }];
+        cold.persist_buckets(&batch_three, &[]).unwrap();
+
+        let conn = pool.get().unwrap();
+        let (
+            ifindex,
+            ingress_bytes,
+            ingress_packets,
+            egress_bytes,
+            egress_packets,
+            status,
+            create_time_ms,
+        ): (i64, i64, i64, i64, i64, i64, i64) = conn
+            .query_row(
+                "SELECT ifindex, ingress_bytes, ingress_packets, egress_bytes, egress_packets,
+                        status, create_time_ms
+                 FROM conn_metrics_1m
+                 WHERE create_time = 1000 AND cpu_id = 1 AND report_time = 60000",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(ifindex, 44, "an equal create_time_ms must take the later ifindex");
+        assert_eq!(ingress_bytes, 300);
+        assert_eq!(ingress_packets, 30);
+        assert_eq!(egress_bytes, 900);
+        assert_eq!(egress_packets, 90);
+        assert_eq!(status, 2, "GREATEST(status) must keep the larger status");
+        assert_eq!(create_time_ms, 9_000);
+    }
+
+    #[test]
+    fn cold_iface_bucket_upsert_accumulates_duplicate_keys() {
+        init_test_tracing();
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("iface_merge.duckdb");
+        let pool = initialize_cold_storage(&db_path, &test_metric_config()).unwrap();
+        let cold = DuckdbColdStore::new(pool.clone());
+
+        // Duplicate (ifindex, report_time) within one batch must fold
+        // additively per counter and keep the max active_conns, exactly like
+        // the row-by-row upsert did.
+        let batch_one = vec![
+            IfaceBucketWrite {
+                ifindex: 5,
+                report_time: 120_000,
+                ingress_bytes: 100,
+                ingress_packets: 10,
+                egress_bytes: 200,
+                egress_packets: 20,
+                active_conns: 3,
+            },
+            IfaceBucketWrite {
+                ifindex: 5,
+                report_time: 120_000,
+                ingress_bytes: 200,
+                ingress_packets: 20,
+                egress_bytes: 50,
+                egress_packets: 5,
+                active_conns: 7,
+            },
+        ];
+        cold.persist_buckets(&[], &batch_one).unwrap();
+
+        // A later batch keeps accumulating against the stored row.
+        let batch_two = vec![IfaceBucketWrite {
+            ifindex: 5,
+            report_time: 120_000,
+            ingress_bytes: 50,
+            ingress_packets: 5,
+            egress_bytes: 500,
+            egress_packets: 50,
+            active_conns: 2,
+        }];
+        cold.persist_buckets(&[], &batch_two).unwrap();
+
+        let conn = pool.get().unwrap();
+        let (ingress_bytes, ingress_packets, egress_bytes, egress_packets, active_conns): (
+            i64,
+            i64,
+            i64,
+            i64,
+            i64,
+        ) = conn
+            .query_row(
+                "SELECT ingress_bytes, ingress_packets, egress_bytes, egress_packets, active_conns
+                 FROM iface_metrics_5s
+                 WHERE ifindex = 5 AND report_time = 120000",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+            )
+            .unwrap();
+        assert_eq!(ingress_bytes, 350);
+        assert_eq!(ingress_packets, 35);
+        assert_eq!(egress_bytes, 750);
+        assert_eq!(egress_packets, 75);
+        assert_eq!(active_conns, 7, "active_conns must keep the max");
+    }
+
+    #[test]
+    fn cold_bucket_large_interleaved_batch_is_chunked_and_complete() {
+        init_test_tracing();
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("bucket_chunks.duckdb");
+        let pool = initialize_cold_storage(&db_path, &test_metric_config()).unwrap();
+
+        // More rows than one upsert chunk per table, with the kinds
+        // interleaved so grouping by table is exercised on every iteration.
+        let kinds = [BucketKind::Minute, BucketKind::Hour, BucketKind::Day];
+        let mut remaining = [2500usize, 1300, 700];
+        let mut writes: Vec<BucketWrite> = Vec::new();
+        let mut next_key: u64 = 20_000;
+        loop {
+            let mut pushed = false;
+            for (kind_slot, remaining_count) in remaining.iter_mut().enumerate() {
+                if *remaining_count == 0 {
+                    continue;
+                }
+                *remaining_count -= 1;
+                pushed = true;
+                let create_time = next_key;
+                next_key += 1;
+                let report_time = 700_000 + create_time;
+                writes.push(BucketWrite {
+                    kind: kinds[kind_slot],
+                    metric: test_metric(create_time, 0, report_time, 100, 10, 200, 20),
+                    bucket_report_time: report_time,
+                });
+            }
+            if !pushed {
+                break;
+            }
+        }
+        assert_eq!(writes.len(), 2500 + 1300 + 700);
+
+        let iface_writes: Vec<IfaceBucketWrite> = (0..900)
+            .map(|index| IfaceBucketWrite {
+                ifindex: (index % 4) as u32 + 1,
+                report_time: 800_000 + index as u64,
+                ingress_bytes: index as u64,
+                ingress_packets: index as u64,
+                egress_bytes: index as u64,
+                egress_packets: index as u64,
+                active_conns: index as u32,
+            })
+            .collect();
+
+        let cold = DuckdbColdStore::new(pool.clone());
+        let stats = cold.persist_buckets(&writes, &iface_writes).unwrap();
+        assert_eq!(stats.rows, writes.len());
+        assert_eq!(stats.iface_rows, iface_writes.len());
+
+        let conn = pool.get().unwrap();
+        let minute_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM conn_metrics_1m", [], |row| row.get(0)).unwrap();
+        let hour_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM conn_metrics_1h", [], |row| row.get(0)).unwrap();
+        let day_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM conn_metrics_1d", [], |row| row.get(0)).unwrap();
+        let iface_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM iface_metrics_5s", [], |row| row.get(0)).unwrap();
+        assert_eq!(minute_count, 2500);
+        assert_eq!(hour_count, 1300);
+        assert_eq!(day_count, 700);
+        assert_eq!(iface_count, iface_writes.len() as i64);
+    }
+
+    /// Commit `row_count` rows and close the database without checkpointing,
+    /// so the committed data is left sitting in a leftover WAL file — the
+    /// on-disk state an abnormal shutdown (kill, power loss, abort) leaves
+    /// behind.
+    fn write_leftover_wal(db_path: &Path, row_count: u64) {
+        let writer_manager = DuckdbConnectionManager::file_with_flags(
+            db_path,
+            build_duckdb_config(&test_metric_config()).unwrap(),
+        )
+        .unwrap();
+        let writer_pool = r2d2::Pool::builder().max_size(1).build(writer_manager).unwrap();
+        {
+            let conn = writer_pool.get().unwrap();
+            connect_schema::create_metrics_table(&conn).unwrap();
+            conn.execute("PRAGMA disable_checkpoint_on_shutdown", []).unwrap();
+            conn.execute("PRAGMA wal_autocheckpoint='1GB'", []).unwrap();
+            // One literal-values insert per statement keeps this helper fast;
+            // going through DuckdbColdStore would bind hundreds of thousands
+            // of prepared parameters in debug builds.
+            for chunk_start in (0..row_count).step_by(5_000) {
+                let mut sql = String::from(
+                    "INSERT INTO conn_metrics_1m (
+                        create_time, cpu_id, report_time, ifindex,
+                        ingress_bytes, ingress_packets, egress_bytes, egress_packets,
+                        status, create_time_ms
+                    ) VALUES ",
+                );
+                for index in chunk_start..(chunk_start + 5_000).min(row_count) {
+                    let create_time = 30_000 + index;
+                    sql.push_str(&format!(
+                        "({create_time}, 0, {}, 10, 100, 10, 200, 20, 2, {create_time}),",
+                        900_000 + create_time,
+                    ));
+                }
+                sql.pop();
+                conn.execute_batch(&sql).unwrap();
+            }
+        }
+        drop(writer_pool);
+    }
+
+    #[test]
+    fn startup_replays_leftover_wal_before_opening_with_configured_memory() {
+        init_test_tracing();
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("wal_leftover.duckdb");
+
+        write_leftover_wal(&db_path, 50_000);
+
+        let leftover_wal = wal_size_bytes(&db_path);
+        assert!(
+            leftover_wal > WAL_PRECHECKPOINT_THRESHOLD_BYTES,
+            "expected a leftover wal above {} bytes, got {}",
+            WAL_PRECHECKPOINT_THRESHOLD_BYTES,
+            leftover_wal,
+        );
+
+        // A tighter-than-default limit for the constrained open: with the WAL
+        // drained first it must still succeed cheaply.
+        let mut config = test_metric_config();
+        config.db_max_memory_mb = 64;
+        let recovered = initialize_cold_storage_with_recovery(&db_path, &config).unwrap();
+        assert!(
+            wal_size_bytes(&db_path) < WAL_PRECHECKPOINT_THRESHOLD_BYTES,
+            "expected the recovery open to drain the leftover wal, got {} bytes",
+            wal_size_bytes(&db_path),
+        );
+
+        let conn = recovered.get().unwrap();
+        let count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM conn_metrics_1m", [], |row| row.get(0)).unwrap();
+        assert_eq!(count, 50_000, "wal replay must preserve committed rows");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #220
Fixes #203

两个独立修复,分别对应 #220(启动崩溃循环)与 #203(bucket 落盘极慢)。均在真实路由器(Debian 13 / 8GB RAM / 0.23.1,库 1.48GB、conn_metrics_1m 378 万行)上以线上库副本完成复现与验证。

## 1. 启动回放残留 WAL 崩溃循环(#220)

**根因**:DuckDB 在 open 调用内部同步回放未 checkpoint 的 WAL,且回放受连接 `max_memory` 约束。insert 型 WAL 回放会重走主键索引(ART),内存放大实测 **20-31x**:16.3MB 残留 WAL 回放需要 ~330MB,超过默认 `db_max_memory_mb=256` → `FatalException` 跨 FFI 表现为 terminate→SIGABRT,**不可捕获**,现有只处理 `Err` 的恢复阶梯永远走不到,`Restart=always` 无限重启(线上 8/21 10:23 起 3 分钟内 7 次)。

**线上日志与副本复现完全一致**:
```
TransactionContext Error: Failure while replaying WAL file ... could not
allocate block of size 256.0 KiB (244.0 MiB/244.1 MiB used)
```
(用与二进制相同路径的独立程序预置 `Config.max_memory=256MB` + 16.3MB 残留 WAL 打开同一库副本,逐字复现;同一 WAL 在 1024MB 上限下 0.1s/1MB 峰值回放成功。)

**修复**:`initialize_cold_storage_with_recovery` 入口处,若 WAL > 1MB,先用一次性连接(max(配置值, 1024MB, 32×WAL大小))执行 `CHECKPOINT` 排干 WAL 再按配置上限打开;失败仅告警并落入现有恢复阶梯,不阻塞启动。对正常库(WAL≈0)无任何行为变化。

## 2. bucket 写入"假批量"(#203)

**根因**:批量提交虽是单事务+prepared 复用,但仍是**逐条 execute**——DuckDB prepared 逐行解释执行,5000 行批次对 378 万行表耗时 **15.7-18.3s**(线上 13-23s/次、写线程 CPU 99.9%)。

**修复**:改为单条 `INSERT ... SELECT ... FROM (VALUES ...) AS batch(...)` 走向量化路径,同批次实测 **~0.5s(约 30-40x)**。两点必要处理:

- **VALUES 必须包在子查询里**:扁平多行 `INSERT ... VALUES ... ON CONFLICT` 行数上百后 Binder 报错(这也解释了当初为何绕开多行写法);
- **同批次重复主键先在 Rust 内折叠**:DuckDB 对同语句内重复键的 ON CONFLICT 合并结果未定义(duckdb#8147),折叠逻辑与原单行 UPSERT 语义逐条等价(计数器取 GREATEST、`create_time_ms >=` 时 ifindex 覆盖、iface 计数器累加/active_conns 取最大,溢出改为 saturating_add)。
- 批次按 1024 行分块,绑定参数上限 ~10k。

## 测试

`cargo test -p landscape --features duckdb-bundled metric` —— **24/24 通过**(新增 5 个):

- 同批次冲突键合并语义(含 `create_time_ms` 相同时后到者胜的 tie-break)
- iface 重复键累加折叠
- 大批次交错分块完整性(2500/1300/700 conn + 900 iface 行)
- 启动前回放残留 WAL 后再以配置上限打开(50k 行 WAL、恢复配置 64MB,验证低于 floor 时抬升生效)

## 备注

- 基于分支 `duck`(`d4edebc1`)而非 main:文件已被该 refactor 重排,fix 落在其上无冲突。
- DNS 路径已是真批量,未改动。
