### PR TITLE
fix(ebpf): redirect_pkg_handler exits with ENOTDIR when bonding module is loaded

### DIFF
--- a/landscape-ebpf/src/bin/redirect_pkg_handler.rs
+++ b/landscape-ebpf/src/bin/redirect_pkg_handler.rs
@@ -163,6 +163,14 @@ fn get_first_non_loopback_with_peer() -> Result<(String, i32, i32), io::Error> {
             continue;
         }
 
+        // /sys/class/net 下可能混有非目录条目，例如内核加载 bonding 模块后生成的
+        // bonding_masters 文件。对其读取 ifindex 会返回 ENOTDIR，导致整个 handler
+        // 启动即退出、不再 enroll。跳过非目录/非符号链接条目。
+        let file_type = entry.file_type()?;
+        if !file_type.is_dir() && !file_type.is_symlink() {
+            continue;
+        }
+
         let iface_path = entry.path();
 
         // 读取 ifindex


### PR DESCRIPTION
## Problem

`redirect_pkg_handler` exits immediately on hosts where the kernel has loaded the `bonding` module, even when no bond interface is configured:

```
INFO redirect_pkg_handler: Error: Os { code: 20, kind: NotADirectory, message: "Not a directory" }
```

`get_first_non_loopback_with_peer()` iterates `/sys/class/net` and does `fs::read_to_string(<entry>/ifindex)?` for every entry except `lo`. But `/sys/class/net` is not guaranteed to contain only interface directories: once `bonding` is loaded the kernel creates a **regular file** `bonding_masters` there. It sorts before `eth*`, so the first non-`lo` entry is a file, `read_to_string("bonding_masters/ifindex")` fails with `ENOTDIR`, the `?` propagates and the handler exits before enrolling with the router.

Effect from the user's side: the flow has no redirect target, so every foreign TCP connection of that flow goes direct and times out, while DNS (separate inbound) keeps working — confusing to diagnose. Restarting the container does not help; only `rmmod bonding` does.

## Fix

Skip entries that are neither a directory nor a symlink before touching `ifindex`/`iflink`. Real interfaces under `/sys/class/net` are symlinks to `/sys/devices/...`, so they are unaffected.

## Verification

- Reproduced on landscape v0.21.4 + `landscape-edge:amd64-20` with `bonding` loaded (`lsmod` refcount 0, `/proc/net/bonding/` empty): handler missing from `docker top`, log shows the `NotADirectory` error above; `rmmod bonding && docker restart` restores it.
- Confirmed the loop is unchanged on current `main` (`245423bf`).
- `cargo check -p landscape-ebpf --bin redirect_pkg_handler` passes on Linux (Debian bookworm, rust 1.98 stable) against this branch.

---

中文摘要：宿主机加载 `bonding` 模块后 `/sys/class/net` 会多出一个普通文件 `bonding_masters`，按字母序排在 `eth*` 之前。`get_first_non_loopback_with_peer()` 对它读 `ifindex` 触发 `ENOTDIR`，`?` 直接把 handler 退出，不再向主程序 enroll，表现为该 flow 的国外 TCP 全部直连超时而 DNS 正常。本 PR 在读取前跳过非目录/非符号链接条目。
