### PR TITLE
Add per-source GeoIP refresh support

### DIFF
--- a/landscape-webserver/src/geo/ips.rs
+++ b/landscape-webserver/src/geo/ips.rs
@@ -22,6 +22,7 @@ pub fn get_geo_ip_config_paths() -> OpenApiRouter<LandscapeApp> {
         .routes(routes!(add_many_geo_ips))
         .routes(routes!(get_geo_ip_rule, del_geo_ip))
         .routes(routes!(get_geo_ip_cache, refresh_geo_ip_cache))
+        .routes(routes!(refresh_geo_ip_config_by_name))
         .routes(routes!(search_geo_ip_cache))
         .routes(routes!(get_geo_ip_cache_detail))
         .merge(upload_router)
@@ -105,6 +106,21 @@ async fn get_geo_ip_cache(
 )]
 async fn refresh_geo_ip_cache(State(state): State<LandscapeApp>) -> LandscapeApiResult<()> {
     state.geo_ip_service.refresh(true).await;
+    LandscapeApiResp::success(())
+}
+
+#[utoipa::path(
+    post,
+    path = "/ips/{name}/refresh",
+    tag = "Geo IPs",
+    params(("name" = String, Path, description = "Geo IP config name")),
+    responses((status = 200, description = "Success"))
+)]
+async fn refresh_geo_ip_config_by_name(
+    State(state): State<LandscapeApp>,
+    Path(name): Path<String>,
+) -> LandscapeApiResult<()> {
+    state.geo_ip_service.refresh_one(&name).await;
     LandscapeApiResp::success(())
 }
 

--- a/landscape-webui/src/api/geo/ip.ts
+++ b/landscape-webui/src/api/geo/ip.ts
@@ -6,6 +6,7 @@ import {
   delGeoIp,
   getGeoIpCache,
   refreshGeoIpCache,
+  refreshGeoIpConfigByName,
   searchGeoIpCache,
   getGeoIpCacheDetail,
   updateGeoIpByUpload as _updateGeoIpByUpload,
@@ -53,6 +54,10 @@ export async function get_geo_cache_key(
 
 export async function refresh_geo_cache_key(): Promise<void> {
   await refreshGeoIpCache();
+}
+
+export async function refresh_geo_ip_by_name(name: string): Promise<void> {
+  await refreshGeoIpConfigByName(name);
 }
 
 export async function search_geo_ip_cache(

--- a/landscape-webui/src/components/geo/ip/config/GeoIpItemCard.vue
+++ b/landscape-webui/src/components/geo/ip/config/GeoIpItemCard.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { delete_geo_ip_config, update_geo_ip_by_upload } from "@/api/geo/ip";
+import {
+  delete_geo_ip_config,
+  refresh_geo_ip_by_name,
+  update_geo_ip_by_upload,
+} from "@/api/geo/ip";
 import type { GeoIpSourceConfig } from "@landscape-router/types/api/schemas";
 import { computed, ref } from "vue";
 import { useFrontEndStore } from "@/stores/front_end_config";
@@ -35,6 +39,18 @@ const show_upload = ref(false);
 const onGeoUpload = async (formData: FormData) => {
   await update_geo_ip_by_upload(props.geo_ip_source.name, formData);
 };
+
+const refreshing = ref(false);
+async function force_refresh() {
+  refreshing.value = true;
+  try {
+    await refresh_geo_ip_by_name(props.geo_ip_source.name);
+    emit("refresh");
+    emit("refresh:keys");
+  } finally {
+    refreshing.value = false;
+  }
+}
 </script>
 <template>
   <n-flex>
@@ -109,6 +125,19 @@ const onGeoUpload = async (formData: FormData) => {
           >
             {{ t("geo.item_card.update_with_file") }}
           </n-button>
+
+          <n-popconfirm
+            v-if="geo_ip_source.source.t === 'url'"
+            :positive-button-props="{ loading: refreshing }"
+            @positive-click="force_refresh"
+          >
+            <template #trigger>
+              <n-button size="small" type="primary" secondary>
+                {{ t("geo.item_card.force_refresh") }}
+              </n-button>
+            </template>
+            {{ t("geo.item_card.force_refresh_confirm") }}
+          </n-popconfirm>
 
           <n-button
             size="small"


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/geo/ips/{name}/refresh` for refreshing a single GeoIP source.
- Register the endpoint in the generated OpenAPI specification.
- Add a per-source refresh action to URL-based GeoIP source cards.
- Refresh the GeoIP configuration and cache-key views after the operation completes.

## Motivation

GeoSite sources already support refreshing an individual source, while GeoIP sources only support refreshing the entire cache.

This change makes the GeoIP behavior consistent with GeoSite and avoids reloading unrelated GeoIP sources when only one source needs to be updated.

## API

`POST /api/v1/geo/ips/{name}/refresh`

The endpoint calls `geo_ip_service.refresh_one(name)`, matching the existing GeoSite implementation.

## Testing

- TypeScript type checking passed.
- Frontend tests passed: 22 tests.