### PR TITLE
ci: enable gateway on musl (Alpine) builds by installing cmake

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -247,7 +247,7 @@ jobs:
             target: x86_64-unknown-linux-musl
             toolchain: stable
             bindgen: false
-            gateway: false
+            gateway: true
 
     container: 
       image: thisseanzhang/landscape:build_base_musl
@@ -258,7 +258,7 @@ jobs:
 
       - name: Setup sccache
         run: |
-          apk add --no-cache curl gzip tar wget
+          apk add --no-cache cmake curl gzip tar wget
           sccache_arch=${{ matrix.settings.architecture }}
           if [ "${sccache_arch}" = "x86_64" ] || [ "${sccache_arch}" = "aarch64" ]; then
             wget -qO- https://github.com/mozilla/sccache/releases/download/${sccache_version}/sccache-${sccache_version}-${sccache_arch}-unknown-linux-musl.tar.gz | tar -xzf - -C /usr/local/bin/ --strip-components=1

--- a/dockerfiles/build-musl/Dockerfile
+++ b/dockerfiles/build-musl/Dockerfile
@@ -10,6 +10,7 @@ RUN apk update && apk add --no-cache \
     gcc \
     build-base \
     make \
+    cmake \
     pkgconf \
     elfutils-dev \
     linux-headers


### PR DESCRIPTION
## Summary / 概述

Re-enables the gateway reverse-proxy feature in the `x86_64-unknown-linux-musl` (Alpine) release builds. The feature was disabled in b5879080 because the musl CI job broke on the day gateway landed — but the real cause was a missing `cmake` in the Alpine build image, not a musl incompatibility.

在 `x86_64-unknown-linux-musl`（Alpine）发布产物中重新启用网关反向代理功能。该功能在 b5879080 中被关闭，原因是 gateway 合入当天 musl CI 任务失败——但真实原因只是 Alpine 构建镜像里缺少 `cmake`，并不是 musl 平台不兼容。

## Root Cause / 根因

`pingora-core` pins `flate2` to the zlib-ng backend, and `libz-ng-sys`'s build script invokes `cmake`. The gnu targets build on GitHub ubuntu runners where cmake is preinstalled, while the musl job builds inside `thisseanzhang/landscape:build_base_musl`, whose `apk add` list never included cmake. Reproduced in the exact same image: the only failing crate in the whole tree is `libz-ng-sys`, with `is cmake not installed?`.

`pingora-core` 将 `flate2` 固定为 zlib-ng 后端，而 `libz-ng-sys` 的构建脚本需要调用 `cmake`。gnu 目标跑在预装了 cmake 的 GitHub ubuntu runner 上；musl 任务则在 `build_base_musl` 镜像内构建，其 `apk add` 列表从未包含 cmake。已在同款镜像中复现：整个依赖树中唯一失败的 crate 是 `libz-ng-sys`，报错为 `is cmake not installed?`。

## Changes / 改动内容

- `.github/workflows/build-and-release.yml`: add `cmake` to the musl job's `apk add` list, and flip `gateway: false` → `true` for the musl matrix entry (the `gateway=true` build branch already exists in the script).
- `dockerfiles/build-musl/Dockerfile`: add `cmake` so the image definition stays in sync for its next rebuild.

- `.github/workflows/build-and-release.yml`：在 musl 任务的 `apk add` 列表中加入 `cmake`，并将 musl matrix 条目的 `gateway: false` 改为 `true`（构建脚本中 `gateway=true` 分支本就存在）。
- `dockerfiles/build-musl/Dockerfile`：加入 `cmake`，使镜像定义在下次重建后保持一致。

## Verification / 验证

Build-level and runtime-level verification were both carried out in the exact CI image (`thisseanzhang/landscape:build_base_musl`), and full transcripts are attached in the comments below. In short: the CI build steps pass verbatim with gateway on (`VERIFY_OK`), and an end-to-end run inside an Alpine container shows the gateway proxying real traffic on both HTTP :80 and HTTPS :443, with TLS terminated by a generated certificate (`E2E_RESULT=PASS`).

构建级与运行时级验证均在 CI 同款镜像（`thisseanzhang/landscape:build_base_musl`）中完成，完整记录见下方评论。摘要：按 CI 原步骤、开启 gateway 构建通过（`VERIFY_OK`）；在 Alpine 容器内端到端运行，网关在 HTTP :80 与 HTTPS :443 上均成功代理了真实流量，HTTPS 由生成的证书终止 TLS（`E2E_RESULT=PASS`）。

## Notes / 备注

The Woodpecker pipeline that rebuilds `build_base_musl` only triggers on `dockerfiles/build/*` path changes, so the workflow-side `apk add cmake` is what takes effect immediately; the Dockerfile edit keeps the image correct for its next (manual) rebuild. The `gateway: false` on loongarch64 is a separate glibc cross-compilation topic and is intentionally left untouched by this PR.

重建 `build_base_musl` 镜像的 Woodpecker 流水线只在 `dockerfiles/build/*` 路径变更时触发，因此立即生效的是 workflow 里的 `apk add cmake`；Dockerfile 的修改保证镜像下次（手动）重建后保持一致。loongarch64 上的 `gateway: false` 属于另一个 glibc 交叉编译话题，本 PR 有意不动它。
