### PR TITLE
fix: downstream route h_source uses zero MAC causing switch drops

### DIFF
--- a/landscape-common/src/lan_service/lan_route/mod.rs
+++ b/landscape-common/src/lan_service/lan_route/mod.rs
@@ -63,12 +63,21 @@ pub struct StaticRouteConfig {
 }
 
 impl StaticRouteConfig {
-    pub fn to_lan_info(&self, ifindex: u32, iface_name: &str) -> LanRouteInfo {
+    pub fn to_lan_info(
+        &self,
+        ifindex: u32,
+        iface_name: &str,
+        mac: Option<MacAddr>,
+    ) -> LanRouteInfo {
         LanRouteInfo {
             ifindex,
             iface_name: iface_name.to_string(),
             iface_ip: self.subnet,
-            mac: Some(MacAddr::zero()),
+            // 下一跳路由的源 MAC 必须是出口网卡的真实 MAC。
+            // 若填 Some(MacAddr::zero())，eBPF 会把 00:00:00:00:00:00
+            // 写成以太网源地址，部分交换机/旁路由会丢包或学错绑定。
+            // 传 None 时 has_mac=false，eBPF 走不重写 MAC 的兜底分支。
+            mac,
             prefix: self.sub_prefix,
             mode: LanRouteMode::NextHop { next_hop_ip: self.next_hop },
         }

--- a/landscape-ebpf/src/bpf/xdp_lan_intro.bpf.c
+++ b/landscape-ebpf/src/bpf/xdp_lan_intro.bpf.c
@@ -472,7 +472,8 @@ static __always_inline int xdp_route4_lan_redirect_check_in_lan(struct xdp_md *c
 
             struct mac_value_v4 new_val = {.ifindex = lan_info->ifindex, .proto = ETH_IPV4};
             __builtin_memcpy(new_val.mac, fib.dmac, 6);
-            __builtin_memcpy(new_val.dev_mac, lan_info->mac_addr, 6);
+            // fib.smac 才是出口网卡真实源 MAC（与 xdp_wan_route 的 FIB 兜底一致）。
+            __builtin_memcpy(new_val.dev_mac, fib.smac, 6);
             bpf_map_update_elem(&ip_mac_v4, &mac_key, &new_val, BPF_ANY);
 
             void *data = (void *)(long)ctx->data;
@@ -480,7 +481,7 @@ static __always_inline int xdp_route4_lan_redirect_check_in_lan(struct xdp_md *c
             struct ethhdr *eth = data;
             if ((void *)(eth + 1) > data_end) return XDP_PASS;
             __builtin_memcpy(eth->h_dest, fib.dmac, 6);
-            __builtin_memcpy(eth->h_source, lan_info->mac_addr, 6);
+            __builtin_memcpy(eth->h_source, fib.smac, 6);
             // ld_bpf_log("bpf_redirect 2");
             return xdp_redirect_or_tc_handoff(ctx, lan_info->ifindex, 0);
         }
@@ -540,7 +541,8 @@ static __always_inline int xdp_route6_lan_redirect_check_in_lan(struct xdp_md *c
 
             struct mac_value_v6 new_val = {.ifindex = lan_info->ifindex, .proto = ETH_IPV6};
             __builtin_memcpy(new_val.mac, fib.dmac, 6);
-            __builtin_memcpy(new_val.dev_mac, lan_info->mac_addr, 6);
+            // fib.smac 才是出口网卡真实源 MAC（与 xdp_wan_route 的 FIB 兜底一致）。
+            __builtin_memcpy(new_val.dev_mac, fib.smac, 6);
             bpf_map_update_elem(&ip_mac_v6, &hop_key, &new_val, BPF_ANY);
 
             void *data = (void *)(long)ctx->data;
@@ -548,7 +550,7 @@ static __always_inline int xdp_route6_lan_redirect_check_in_lan(struct xdp_md *c
             struct ethhdr *eth = data;
             if ((void *)(eth + 1) > data_end) return XDP_PASS;
             __builtin_memcpy(eth->h_dest, fib.dmac, 6);
-            __builtin_memcpy(eth->h_source, lan_info->mac_addr, 6);
+            __builtin_memcpy(eth->h_source, fib.smac, 6);
             return xdp_redirect_or_tc_handoff(ctx, lan_info->ifindex, 0);
         }
         return 0;
@@ -590,7 +592,12 @@ static __always_inline int xdp_route4_search_cache_in_lan(struct xdp_md *ctx,
                     struct ethhdr *eth = data;
                     if ((void *)(eth + 1) > data_end) return XDP_DROP;
                     __builtin_memcpy(eth->h_dest, mac_val->mac, 6);
-                    __builtin_memcpy(eth->h_source, mac_val->dev_mac, 6);
+                    // 自学习(neigh_learn)/DAD 的表项没有 dev_mac，直接写会产生
+                    // 00:00:00:00:00:00 源 MAC；与 IPv6 分支保持一致，
+                    // 此时保留原始源 MAC。
+                    if (!is_zero_mac(mac_val->dev_mac)) {
+                        __builtin_memcpy(eth->h_source, mac_val->dev_mac, 6);
+                    }
                 }
             }
             if (!target->xdp_redirect_able) {

--- a/landscape-ebpf/src/tests/chain/lan_intro.rs
+++ b/landscape-ebpf/src/tests/chain/lan_intro.rs
@@ -642,6 +642,11 @@ fn xdp_lan_intro_known_lan_fib_fallback() {
         // FIB target must be a device other than the ingress (host end), so the
         // route points out a second pair kept in the test netns.
         out_pair = VethPair::create("lrfout");
+        // 固定 out 端 MAC，便于确定性地断言 FIB 填充的 dev_mac(fib.smac)。
+        Command::new("ip")
+            .args(["link", "set", out_pair.host(), "address", "02:00:00:00:00:aa"])
+            .output()
+            .unwrap();
     }
     let peer = pair.peer();
 
@@ -730,7 +735,7 @@ fn xdp_lan_intro_known_lan_fib_fallback() {
     let raw = mac_after.unwrap();
     assert_eq!(&raw[0..4], &out_h_i.to_ne_bytes(), "FIB cache ifindex = lan_info->ifindex");
     assert_eq!(&raw[4..10], &[0x02, 0, 0, 0, 0, 0x05], "FIB resolved MAC from static neigh");
-    assert_eq!(&raw[10..16], &[0u8; 6], "FIB cache dev_mac = lan_info->mac_addr");
+    assert_eq!(&raw[10..16], &[0x02, 0, 0, 0, 0, 0xaa], "FIB cache dev_mac = fib.smac");
     assert_eq!(&raw[16..18], &0x0800u16.to_be_bytes(), "FIB cache proto = ETH_P_IP");
 
     // second send: MAC cache hit → still redirected

--- a/landscape/src/lan_service/lan_route_service.rs
+++ b/landscape/src/lan_service/lan_route_service.rs
@@ -47,7 +47,7 @@ impl ServiceStarterTrait for RouteLanService {
                     .static_routes
                     .into_iter()
                     .flat_map(|routes| routes.into_iter())
-                    .map(|e2| e2.to_lan_info(iface.index, &iface.name))
+                    .map(|e2| e2.to_lan_info(iface.index, &iface.name, iface.mac))
                     .collect();
 
                 for info in static_routes {


### PR DESCRIPTION
- to_lan_info: accept real MAC from caller instead of MacAddr::zero()
- xdp_lan_redirect_v4/v6: use fib.smac for h_source in FIB fallback path
- xdp_search_route_in_lan_v4: skip h_source rewrite when dev_mac is zero
- lan_route_service: pass iface.mac to to_lan_info
- lan_intro test: pin out MAC to 02:00:00:00:00:aa for deterministic assertion